### PR TITLE
Release version 4.2.1 to fix the handling of `<remote>/HEAD` symbolic…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "speedy-git-ext" extension will be documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [4.2.1] - 2026-05-21
+
+### Fixed
+- HEAD bullseye indicator no longer appears on the wrong commit. The previous build surfaced `<remote>/HEAD` (e.g. `origin/HEAD`) as a normal remote-branch badge, and right-clicking it → **Fast-forward Local Branch from Remote** ran `git fetch origin HEAD:HEAD`, which silently created a stray local branch named `HEAD` (`refs/heads/HEAD`). Once present, every subsequent git command produced `warning: refname 'HEAD' is ambiguous` and Speedy Git painted the HEAD bullseye on whatever commit that stray ref happened to point at — visible even after refresh, fetch, checkout, or IDE restart.
+- `<remote>/HEAD` is git's symbolic ref for the remote's default branch, not a real branch, so it is now filtered out of commit decorations and the branch list — no badge, no right-click menu, no Compare entry. Matches how Git Graph, GitLens, GitKraken, and Sourcetree handle it.
+- Defensive guards added at the service layer: `fastForwardFromRemote`, `createBranch`, and `renameBranch` now reject `HEAD` as a local branch name, so even if a future UI path passes it through, the extension refuses the write instead of creating another stray `refs/heads/HEAD`.
+- Users who already have the stray ref from a previous version can remove it with `git update-ref -d refs/heads/HEAD` (the bullseye disappears on next refresh). `git branch -d HEAD` does not work because git resolves `HEAD` to its symbolic ref instead of the literal branch.
+
 ## [4.2.0] - 2026-05-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speedy-git-ext",
   "displayName": "Speedy Git",
   "description": "A performance-first, lightweight Git graph visualization extension for VS Code",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "publisher": "onlineeric",
   "license": "MIT",
   "repository": {

--- a/src/__tests__/GitBranchService.test.ts
+++ b/src/__tests__/GitBranchService.test.ts
@@ -186,4 +186,42 @@ describe('GitBranchService.fastForwardFromRemote', () => {
       expect(result.error.stderr).toContain('non-fast-forward');
     }
   });
+
+  it('rejects "HEAD" as a branch name without invoking the executor', async () => {
+    // Guards against `git fetch <remote> HEAD:HEAD` ever being able to create a
+    // stray `refs/heads/HEAD`. Even if a UI badge slips through filtering, the
+    // service refuses the write.
+    const service = new GitBranchService('/repo', mockLog);
+    const executeSpy = vi.spyOn(service['executor'], 'execute');
+
+    const result = await service.fastForwardFromRemote('origin', 'HEAD');
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe('VALIDATION_ERROR');
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('GitBranchService reserved-name guards', () => {
+  it('createBranch refuses "HEAD" as the new branch name', async () => {
+    const service = new GitBranchService('/repo', mockLog);
+    const executeSpy = vi.spyOn(service['executor'], 'execute');
+
+    const result = await service.createBranch('HEAD');
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe('VALIDATION_ERROR');
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
+  it('renameBranch refuses "HEAD" as the new branch name', async () => {
+    const service = new GitBranchService('/repo', mockLog);
+    const executeSpy = vi.spyOn(service['executor'], 'execute');
+
+    const result = await service.renameBranch('feature-x', 'HEAD');
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe('VALIDATION_ERROR');
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/gitParsers.test.ts
+++ b/src/__tests__/gitParsers.test.ts
@@ -128,6 +128,18 @@ describe('parseRefs', () => {
       { type: 'remote', name: 'main', remote: 'origin' },
     ]);
   });
+
+  it('drops `<remote>/HEAD` symbolic refs from commit decorations', () => {
+    // origin/HEAD is git's symbolic default-branch marker, not a real branch.
+    // Surfacing it produced a foot-gun where right-click → Fast-Forward ran
+    // `git fetch origin HEAD:HEAD` and created a stray `refs/heads/HEAD`.
+    expect(parseRefs('HEAD -> main, origin/main, origin/HEAD')).toEqual([
+      { type: 'head', name: 'main' },
+      { type: 'remote', name: 'main', remote: 'origin' },
+    ]);
+    expect(parseRefs('upstream/HEAD')).toEqual([]);
+    expect(parseRefs('fork/HEAD')).toEqual([]);
+  });
 });
 
 describe('parseBranchLine', () => {
@@ -181,5 +193,10 @@ describe('parseBranchLine', () => {
     const result = parseBranchLine(branchLine('  main ', ' ', '  hash123  '));
     expect(result!.name).toBe('main');
     expect(result!.hash).toBe('hash123');
+  });
+
+  it('drops `<remote>/HEAD` entries from the branch list', () => {
+    expect(parseBranchLine(branchLine('origin/HEAD', ' ', 'aaa1111'))).toBeNull();
+    expect(parseBranchLine(branchLine('remotes/origin/HEAD', ' ', 'aaa1111'))).toBeNull();
   });
 });

--- a/src/services/GitBranchService.ts
+++ b/src/services/GitBranchService.ts
@@ -1,7 +1,7 @@
 import type { LogOutputChannel } from 'vscode';
 import { GitExecutor } from './GitExecutor.js';
 import { GitError, type Result, err, ok } from '../../shared/errors.js';
-import { validateRefName } from '../utils/gitValidation.js';
+import { validateLocalBranchName, validateRefName } from '../utils/gitValidation.js';
 import { isDirtyWorkingTree } from '../utils/gitQueries.js';
 
 function isBranchNotFullyMerged(stderr: string | undefined): boolean {
@@ -112,7 +112,7 @@ export class GitBranchService {
 
     const remoteCheck = validateRefName(remote);
     if (!remoteCheck.success) return remoteCheck;
-    const branchCheck = validateRefName(branch);
+    const branchCheck = validateLocalBranchName(branch);
     if (!branchCheck.success) return branchCheck;
 
     const fetchResult = await this.executor.execute({
@@ -145,7 +145,7 @@ export class GitBranchService {
 
   async createBranch(name: string, startPoint?: string): Promise<Result<string>> {
     this.log.info(`Create branch: ${name}${startPoint ? ` from ${startPoint}` : ''}`);
-    const nameCheck = validateRefName(name);
+    const nameCheck = validateLocalBranchName(name);
     if (!nameCheck.success) return nameCheck;
     if (startPoint) {
       const startCheck = validateRefName(startPoint);
@@ -164,7 +164,7 @@ export class GitBranchService {
     this.log.info(`Rename branch: ${oldName} → ${newName}`);
     const oldCheck = validateRefName(oldName);
     if (!oldCheck.success) return oldCheck;
-    const newCheck = validateRefName(newName);
+    const newCheck = validateLocalBranchName(newName);
     if (!newCheck.success) return newCheck;
 
     const result = await this.executor.execute({

--- a/src/utils/gitParsers.ts
+++ b/src/utils/gitParsers.ts
@@ -83,6 +83,10 @@ function parseRefPart(part: string): RefInfo | null {
     // Only treat as remote if it starts with a known remote prefix
     if (commonRemotes.includes(potentialRemote)) {
       const branchName = part.slice(slashIndex + 1);
+      // Skip `<remote>/HEAD` — it's git's symbolic ref recording the remote's default
+      // branch, not a real branch. Surfacing it as a branch led to actions like
+      // `git fetch origin HEAD:HEAD` creating a stray local `refs/heads/HEAD`.
+      if (branchName === 'HEAD') return null;
       return { name: branchName, type: 'remote', remote: potentialRemote };
     }
   }
@@ -134,6 +138,12 @@ export function parseBranchLine(line: string): Branch | null {
         branchName = restOfName;
       }
     }
+  }
+
+  // Drop `<remote>/HEAD` — symbolic ref pointing at the remote's default branch,
+  // not a branch we should let users act on.
+  if (remote && branchName === 'HEAD') {
+    return null;
   }
 
   return {

--- a/src/utils/gitValidation.ts
+++ b/src/utils/gitValidation.ts
@@ -18,6 +18,26 @@ export function validateRefName(name: string): Result<string> {
   return { success: true, value: name };
 }
 
+const RESERVED_LOCAL_BRANCH_NAMES = new Set(['HEAD']);
+
+/**
+ * Validates a name that will be used to create or update a local branch
+ * (i.e. anything that ends up writing `refs/heads/<name>`).
+ *
+ * `git branch <name>` already refuses reserved names like "HEAD", but lower-level
+ * refspecs such as `git fetch origin HEAD:HEAD` bypass that check and silently
+ * create a stray `refs/heads/HEAD`, which then makes every subsequent ref lookup
+ * ambiguous. Guard the call sites that can hit that path.
+ */
+export function validateLocalBranchName(name: string): Result<string> {
+  const base = validateRefName(name);
+  if (!base.success) return base;
+  if (RESERVED_LOCAL_BRANCH_NAMES.has(name)) {
+    return err(new GitError(`'${name}' is reserved and cannot be used as a local branch name.`, 'VALIDATION_ERROR'));
+  }
+  return { success: true, value: name };
+}
+
 /** Validates a file path — rejects empty strings and values starting with '-'. */
 export function validateFilePath(filePath: string): Result<string> {
   if (!filePath || filePath.startsWith('-')) {


### PR DESCRIPTION
… refs, preventing the creation of stray local branches named `HEAD`. Updated validation to reject `HEAD` as a local branch name across relevant service methods. Enhanced tests to ensure proper rejection and filtering of `HEAD` in commit decorations and branch lists. Updated changelog to reflect these changes.