### PR TITLE
Fix column resizing behavior for flexible table layouts and left-align date

### DIFF
--- a/webview-ui/src/components/CommitTableHeader.tsx
+++ b/webview-ui/src/components/CommitTableHeader.tsx
@@ -17,6 +17,7 @@ interface ResizeSession {
   columnId: CommitTableColumnId;
   startX: number;
   startWidth: number;
+  isReverse?: boolean;
 }
 
 const COLUMN_LABELS: Record<CommitTableColumnId, string> = {
@@ -45,9 +46,12 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
     }
 
     const handlePointerMove = (event: PointerEvent) => {
+      const deltaX = event.clientX - resizeSession.startX;
+      const effectiveDeltaX = resizeSession.isReverse ? -deltaX : deltaX;
+
       const nextWidth = Math.max(
         COMMIT_TABLE_MIN_WIDTHS[resizeSession.columnId],
-        resizeSession.startWidth + (event.clientX - resizeSession.startX)
+        resizeSession.startWidth + effectiveDeltaX
       );
       updateCommitTableLayout((currentLayout) =>
         setCommitTableColumnPreferredWidth(currentLayout, resizeSession.columnId, nextWidth)
@@ -97,10 +101,25 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
             onDoubleClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
-              handleDoubleClick(column.id);
+              const messageIndex = layout.columns.findIndex((c) => c.id === 'message');
+              if (messageIndex !== -1 && index >= messageIndex && index < layout.columns.length - 1) {
+                handleDoubleClick(layout.columns[index + 1].id);
+              } else {
+                handleDoubleClick(column.id);
+              }
             }}
             onPointerDown={(event) => {
-              const target = layout.columns.find((item) => item.id === column.id);
+              const messageIndex = layout.columns.findIndex((c) => c.id === 'message');
+              let target = layout.columns.find((item) => item.id === column.id);
+              let isReverse = false;
+
+              // Since 'message' uses all remaining space, dragging any separator after it
+              // should resize the *next* column in reverse.
+              if (messageIndex !== -1 && index >= messageIndex && index < layout.columns.length - 1) {
+                target = layout.columns[index + 1];
+                isReverse = true;
+              }
+
               if (!target) {
                 return;
               }
@@ -108,9 +127,10 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
               event.preventDefault();
               event.stopPropagation();
               setResizeSession({
-                columnId: column.id,
+                columnId: target.id,
                 startX: event.clientX,
                 startWidth: target.effectiveWidth,
+                isReverse,
               });
             }}
           />

--- a/webview-ui/src/components/CommitTableRow.tsx
+++ b/webview-ui/src/components/CommitTableRow.tsx
@@ -313,8 +313,8 @@ function renderColumn({
     case 'date':
       return (
         <DateContextMenu authorDate={commit.authorDate}>
-          <div className="flex h-full items-center justify-end">
-            <span className="truncate text-right text-xs text-[var(--vscode-descriptionForeground)]">
+          <div className="flex h-full items-center">
+            <span className="truncate text-xs text-[var(--vscode-descriptionForeground)]">
               {dateFormatter(commit.authorDate)}
             </span>
           </div>


### PR DESCRIPTION
Hi @onlineeric, I have fixed this bug according to my needs. Because I am not an expert in this field, I used LLM to help deal with it. Can you confirm the code is right and does improve the overall experience? Thank you! Below is the reasoning generated by AI:

## Description
This PR fixes an unresponsive UI issue where commit table columns to the right of the `Message` column (such as `Author` and `Date`) could not be easily resized using their left-side separators. It also standardizes the text alignment of the `Date` column.

### Changes
- **Reverse Resizing Algorithm:** Because the `Message` column automatically expands to fill remaining horizontal space, adjusting its preferred width directly via a separator handle produces no visual effect. This PR updates `CommitTableHeader.tsx` so that grabbing any separator *after* the `Message` column resizes the **next** column to its right instead, and inverts the calculation delta. This allows the `Message` column to naturally absorb/yield the correct amount of space, keeping the drag handle glued to the cursor.
- **Double-Click Auto-Fit:** Double clicking a separator after the `Message` column now auto-fits the column to its right, rather than attempting to auto-fit the flexible `Message` column.
- **Left-Aligned Date Column:** Removed `justify-end` and `text-right` from the `Date` column renderer in `CommitTableRow.tsx` to align it consistently with the `Author` and `Message` columns.

### Motivation and Context
Users reported that the boundary between the "Message" and "Author" columns was inactive. Consequently, adjusting the "Author" or "Date" columns required dragging their rightmost boundaries, which is particularly cumbersome for the "Date" column since its right boundary sits against the edge of the VS Code window. This fix makes every single table boundary independently draggable and intuitive.