### PR TITLE
Make commit table column resizing safer and easier to recover

### DIFF
--- a/src/WebviewProvider.ts
+++ b/src/WebviewProvider.ts
@@ -44,6 +44,25 @@ import { GitError, type Result } from '../shared/errors.js';
 import { GitExecutor } from './services/GitExecutor.js';
 import { GitHubAvatarService } from './services/GitHubAvatarService.js';
 
+// Per-column minimum widths — mirrors COMMIT_TABLE_MIN_WIDTHS in commitTableLayout.ts
+// (kept here to avoid a backend ↔ webview-util import).
+const COLUMN_MIN_WIDTHS: Record<string, number> = {
+  graph: 52, hash: 72, message: 160, author: 120, date: 64,
+};
+
+// When healing an oversized stored preferredWidth, derive a per-column ceiling
+// using the same logic as the frontend: max = containerWidth - sum(other min widths).
+// We use 4000 px as a conservative assumed container width (safely within 4K monitors).
+const HEALING_ASSUMED_CONTAINER_WIDTH = 4000;
+
+function computeHealingMaxWidth(columnId: string): number {
+  const minWidth = COLUMN_MIN_WIDTHS[columnId] ?? 0;
+  const otherMinWidths = Object.entries(COLUMN_MIN_WIDTHS)
+    .filter(([id]) => id !== columnId)
+    .reduce((sum, [, w]) => sum + w, 0);
+  return Math.max(minWidth, HEALING_ASSUMED_CONTAINER_WIDTH - otherMinWidths);
+}
+
 function repoLayoutKey(repoPath: string): string {
   const hash = crypto.createHash('sha256').update(repoPath).digest('hex').slice(0, 16);
   return `speedyGit.repoTableLayout.${hash}`;
@@ -149,7 +168,13 @@ function validateCommitTableLayout(
         typeof columnRecord.preferredWidth === 'number'
         && isFinite(columnRecord.preferredWidth)
         && columnRecord.preferredWidth > 0
-          ? Math.round(columnRecord.preferredWidth)
+          ? Math.min(
+              computeHealingMaxWidth(columnId),
+              Math.max(
+                COLUMN_MIN_WIDTHS[columnId] ?? 0,
+                Math.round(columnRecord.preferredWidth)
+              )
+            )
           : columnRecord.preferredWidth !== undefined
             ? defaultColumn.preferredWidth
             : baseColumn.preferredWidth,

--- a/webview-ui/src/components/CommitListSettingsPopover.tsx
+++ b/webview-ui/src/components/CommitListSettingsPopover.tsx
@@ -186,8 +186,7 @@ export function CommitListSettingsPopover() {
               </DndContext>
 
               {commitListMode === 'table' && (
-                <>
-                  <div className="border-t border-[var(--vscode-panel-border)]" />
+                <div className="mt-4 border-t border-[var(--vscode-panel-border)] pt-2">
                   <button
                     type="button"
                     onClick={handleResetWidths}
@@ -196,7 +195,7 @@ export function CommitListSettingsPopover() {
                   >
                     Reset column widths to defaults
                   </button>
-                </>
+                </div>
               )}
             </section>
           </div>

--- a/webview-ui/src/components/CommitListSettingsPopover.tsx
+++ b/webview-ui/src/components/CommitListSettingsPopover.tsx
@@ -21,8 +21,10 @@ import type { CommitListMode, CommitTableColumnId } from '@shared/types';
 import { rpcClient } from '../rpc/rpcClient';
 import { useGraphStore } from '../stores/graphStore';
 import {
+  COMMIT_TABLE_DEFAULT_WIDTHS,
   getOptionalCommitTableColumnIds,
   reorderCommitTableColumns,
+  setCommitTableColumnPreferredWidth,
   setCommitTableColumnVisibility,
 } from '../utils/commitTableLayout';
 import { ColumnsIcon } from './icons';
@@ -83,6 +85,20 @@ export function CommitListSettingsPopover() {
 
     const nextOptionalOrder = arrayMove(optionalColumnIds, oldIndex, newIndex);
     const nextLayout = reorderCommitTableColumns(commitTableLayout, nextOptionalOrder);
+    setCommitTableLayout(nextLayout);
+    rpcClient.persistUIState({ commitTableLayout: nextLayout });
+  };
+
+  const handleResetWidths = () => {
+    // Restore every column's preferredWidth to its factory default.
+    let nextLayout = commitTableLayout;
+    for (const [columnId, defaultWidth] of Object.entries(COMMIT_TABLE_DEFAULT_WIDTHS)) {
+      nextLayout = setCommitTableColumnPreferredWidth(
+        nextLayout,
+        columnId as Parameters<typeof setCommitTableColumnPreferredWidth>[1],
+        defaultWidth
+      );
+    }
     setCommitTableLayout(nextLayout);
     rpcClient.persistUIState({ commitTableLayout: nextLayout });
   };
@@ -168,6 +184,20 @@ export function CommitListSettingsPopover() {
                   </div>
                 </SortableContext>
               </DndContext>
+
+              {commitListMode === 'table' && (
+                <>
+                  <div className="border-t border-[var(--vscode-panel-border)]" />
+                  <button
+                    type="button"
+                    onClick={handleResetWidths}
+                    className="w-full rounded px-2.5 py-1.5 text-left text-xs text-[var(--vscode-descriptionForeground)] transition-colors hover:bg-[var(--vscode-toolbar-hoverBackground)] hover:text-[var(--vscode-foreground)] focus:outline-none"
+                    title="Restore all column widths to their factory defaults"
+                  >
+                    Reset column widths to defaults
+                  </button>
+                </>
+              )}
             </section>
           </div>
           <Popover.Arrow className="fill-[var(--vscode-menu-border)]" />

--- a/webview-ui/src/components/CommitTableHeader.tsx
+++ b/webview-ui/src/components/CommitTableHeader.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { CommitTableColumnId } from '@shared/types';
+import type { CommitTableColumnId, CommitTableLayout } from '@shared/types';
 import { rpcClient } from '../rpc/rpcClient';
 import { useGraphStore } from '../stores/graphStore';
 import {
   COMMIT_TABLE_MIN_WIDTHS,
   computeAutoFitWidth,
   computeColumnMaxWidth,
+  materializeCommitTableEffectiveWidths,
+  resizeCommitTableColumnPair,
   resolveResizeTarget,
   setCommitTableColumnPreferredWidth,
   type ResolvedCommitTableLayout,
@@ -22,6 +24,13 @@ interface ResizeSession {
   /** Width ceiling: containerWidth minus every other visible column's minimum width. */
   maxWidth: number;
   isReverse?: boolean;
+  pairResize?: {
+    baseLayout: CommitTableLayout;
+    leftColumnId: CommitTableColumnId;
+    rightColumnId: CommitTableColumnId;
+    leftStartWidth: number;
+    rightStartWidth: number;
+  };
 }
 
 const COLUMN_LABELS: Record<CommitTableColumnId, string> = {
@@ -51,6 +60,27 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
 
     const handlePointerMove = (event: PointerEvent) => {
       const deltaX = event.clientX - resizeSession.startX;
+      if (resizeSession.pairResize) {
+        const {
+          baseLayout,
+          leftColumnId,
+          rightColumnId,
+          leftStartWidth,
+          rightStartWidth,
+        } = resizeSession.pairResize;
+        updateCommitTableLayout(() =>
+          resizeCommitTableColumnPair({
+            layout: baseLayout,
+            leftColumnId,
+            rightColumnId,
+            leftStartWidth,
+            rightStartWidth,
+            deltaX,
+          })
+        );
+        return;
+      }
+
       const effectiveDeltaX = resizeSession.isReverse ? -deltaX : deltaX;
 
       const nextWidth = Math.min(
@@ -97,6 +127,7 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
       {layout.columns.map((column, index) => {
         const { target: resizeTarget, isReverse } = resolveResizeTarget(layout.columns, index);
         const resizeLabel = `Resize ${COLUMN_LABELS[resizeTarget.id]} column`;
+        const nextColumn = layout.columns[index + 1];
         return (
           <div
             key={column.id}
@@ -116,12 +147,25 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
               onPointerDown={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
+                const pairResize = isReverse && nextColumn
+                  ? {
+                      baseLayout: materializeCommitTableEffectiveWidths(
+                        useGraphStore.getState().commitTableLayout,
+                        layout.columns
+                      ),
+                      leftColumnId: column.id,
+                      rightColumnId: nextColumn.id,
+                      leftStartWidth: column.effectiveWidth,
+                      rightStartWidth: nextColumn.effectiveWidth,
+                    }
+                  : undefined;
                 setResizeSession({
                   columnId: resizeTarget.id,
                   startX: event.clientX,
                   startWidth: resizeTarget.effectiveWidth,
                   maxWidth: computeColumnMaxWidth(layout.columns, resizeTarget.id, layout.tableWidth),
                   isReverse,
+                  pairResize,
                 });
               }}
             />

--- a/webview-ui/src/components/CommitTableHeader.tsx
+++ b/webview-ui/src/components/CommitTableHeader.tsx
@@ -5,6 +5,7 @@ import { useGraphStore } from '../stores/graphStore';
 import {
   COMMIT_TABLE_MIN_WIDTHS,
   computeAutoFitWidth,
+  computeColumnMaxWidth,
   resolveResizeTarget,
   setCommitTableColumnPreferredWidth,
   type ResolvedCommitTableLayout,
@@ -18,6 +19,8 @@ interface ResizeSession {
   columnId: CommitTableColumnId;
   startX: number;
   startWidth: number;
+  /** Width ceiling: containerWidth minus every other visible column's minimum width. */
+  maxWidth: number;
   isReverse?: boolean;
 }
 
@@ -50,9 +53,12 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
       const deltaX = event.clientX - resizeSession.startX;
       const effectiveDeltaX = resizeSession.isReverse ? -deltaX : deltaX;
 
-      const nextWidth = Math.max(
-        COMMIT_TABLE_MIN_WIDTHS[resizeSession.columnId],
-        resizeSession.startWidth + effectiveDeltaX
+      const nextWidth = Math.min(
+        resizeSession.maxWidth,
+        Math.max(
+          COMMIT_TABLE_MIN_WIDTHS[resizeSession.columnId],
+          resizeSession.startWidth + effectiveDeltaX
+        )
       );
       updateCommitTableLayout((currentLayout) =>
         setCommitTableColumnPreferredWidth(currentLayout, resizeSession.columnId, nextWidth)
@@ -114,6 +120,7 @@ export function CommitTableHeader({ layout }: CommitTableHeaderProps) {
                   columnId: resizeTarget.id,
                   startX: event.clientX,
                   startWidth: resizeTarget.effectiveWidth,
+                  maxWidth: computeColumnMaxWidth(layout.columns, resizeTarget.id, layout.tableWidth),
                   isReverse,
                 });
               }}

--- a/webview-ui/src/utils/__tests__/commitTableLayout.test.ts
+++ b/webview-ui/src/utils/__tests__/commitTableLayout.test.ts
@@ -7,7 +7,9 @@ import {
   getOptionalCommitTableColumnIds,
   getOrderedCommitTableColumnIds,
   getVisibleCommitTableColumnIds,
+  materializeCommitTableEffectiveWidths,
   reorderCommitTableColumns,
+  resizeCommitTableColumnPair,
   resolveCommitTableLayout,
   resolveResizeTarget,
   setCommitTableColumnPreferredWidth,
@@ -324,5 +326,107 @@ describe('resolveResizeTarget', () => {
       expect(result.target.id).toBe('date');
       expect(result.isReverse).toBe(false);
     });
+  });
+});
+
+describe('resizeCommitTableColumnPair', () => {
+  it('resizes adjacent columns from a fixed baseline without accumulating previous pointer moves', () => {
+    const layout = createDefaultCommitTableLayout();
+    const resolved = resolveCommitTableLayout({ layout, containerWidth: 900 });
+    const baseLayout = materializeCommitTableEffectiveWidths(layout, resolved.columns);
+    const author = resolved.columns.find((c) => c.id === 'author')!;
+    const date = resolved.columns.find((c) => c.id === 'date')!;
+
+    const after20 = resizeCommitTableColumnPair({
+      layout: baseLayout,
+      leftColumnId: 'author',
+      rightColumnId: 'date',
+      leftStartWidth: author.effectiveWidth,
+      rightStartWidth: date.effectiveWidth,
+      deltaX: 20,
+    });
+    const after25 = resizeCommitTableColumnPair({
+      layout: baseLayout,
+      leftColumnId: 'author',
+      rightColumnId: 'date',
+      leftStartWidth: author.effectiveWidth,
+      rightStartWidth: date.effectiveWidth,
+      deltaX: 25,
+    });
+
+    expect(after20.columns.author.preferredWidth).toBe(author.effectiveWidth + 20);
+    expect(after20.columns.date.preferredWidth).toBe(date.effectiveWidth - 20);
+    expect(after25.columns.author.preferredWidth).toBe(author.effectiveWidth + 25);
+    expect(after25.columns.date.preferredWidth).toBe(date.effectiveWidth - 25);
+  });
+
+  it('keeps message from absorbing the author/date separator movement', () => {
+    const layout = createDefaultCommitTableLayout();
+    const resolved = resolveCommitTableLayout({ layout, containerWidth: 1200 });
+    const baseLayout = materializeCommitTableEffectiveWidths(layout, resolved.columns);
+    const message = resolved.columns.find((c) => c.id === 'message')!;
+    const author = resolved.columns.find((c) => c.id === 'author')!;
+    const date = resolved.columns.find((c) => c.id === 'date')!;
+    expect(message.effectiveWidth).toBeGreaterThan(message.preferredWidth);
+
+    const next = resizeCommitTableColumnPair({
+      layout: baseLayout,
+      leftColumnId: 'author',
+      rightColumnId: 'date',
+      leftStartWidth: author.effectiveWidth,
+      rightStartWidth: date.effectiveWidth,
+      deltaX: 15,
+    });
+    const nextResolved = resolveCommitTableLayout({ layout: next, containerWidth: resolved.tableWidth });
+
+    expect(nextResolved.columns.find((c) => c.id === 'message')!.effectiveWidth).toBe(message.effectiveWidth);
+    expect(nextResolved.columns.find((c) => c.id === 'author')!.effectiveWidth).toBe(author.effectiveWidth + 15);
+    expect(nextResolved.columns.find((c) => c.id === 'date')!.effectiveWidth).toBe(date.effectiveWidth - 15);
+  });
+
+  it('can grow author by dragging the date separator right when date is oversized', () => {
+    const layout = setCommitTableColumnPreferredWidth(
+      createDefaultCommitTableLayout(),
+      'date',
+      500
+    );
+    const resolved = resolveCommitTableLayout({ layout, containerWidth: 600 });
+    const baseLayout = materializeCommitTableEffectiveWidths(layout, resolved.columns);
+    const author = resolved.columns.find((c) => c.id === 'author')!;
+    const date = resolved.columns.find((c) => c.id === 'date')!;
+    expect(author.effectiveWidth).toBe(author.minWidth);
+
+    const next = resizeCommitTableColumnPair({
+      layout: baseLayout,
+      leftColumnId: 'author',
+      rightColumnId: 'date',
+      leftStartWidth: author.effectiveWidth,
+      rightStartWidth: date.effectiveWidth,
+      deltaX: 20,
+    });
+    const nextResolved = resolveCommitTableLayout({ layout: next, containerWidth: resolved.tableWidth });
+
+    expect(nextResolved.columns.find((c) => c.id === 'author')!.effectiveWidth).toBe(author.effectiveWidth + 20);
+    expect(nextResolved.columns.find((c) => c.id === 'date')!.effectiveWidth).toBe(date.effectiveWidth - 20);
+  });
+
+  it('clamps paired resizing at adjacent column minimum widths', () => {
+    const layout = createDefaultCommitTableLayout();
+    const resolved = resolveCommitTableLayout({ layout, containerWidth: 900 });
+    const baseLayout = materializeCommitTableEffectiveWidths(layout, resolved.columns);
+    const author = resolved.columns.find((c) => c.id === 'author')!;
+    const date = resolved.columns.find((c) => c.id === 'date')!;
+
+    const next = resizeCommitTableColumnPair({
+      layout: baseLayout,
+      leftColumnId: 'author',
+      rightColumnId: 'date',
+      leftStartWidth: author.effectiveWidth,
+      rightStartWidth: date.effectiveWidth,
+      deltaX: 999,
+    });
+
+    expect(next.columns.date.preferredWidth).toBe(date.minWidth);
+    expect(next.columns.author.preferredWidth).toBe(author.effectiveWidth + date.effectiveWidth - date.minWidth);
   });
 });

--- a/webview-ui/src/utils/commitTableLayout.ts
+++ b/webview-ui/src/utils/commitTableLayout.ts
@@ -56,6 +56,25 @@ export interface ResolvedCommitTableLayout {
   minimumTableWidth: number;
 }
 
+/**
+ * Compute the maximum preferred width a column may grow to during a drag,
+ * given the current resolved layout and the actual container width.
+ *
+ * The ceiling is defined so that every *other* visible column can still render
+ * at its minimum width.  This is always at least the column's own minimum, so
+ * it can never go negative.
+ */
+export function computeColumnMaxWidth(
+  columns: ResolvedCommitTableColumn[],
+  columnId: CommitTableColumnId,
+  containerWidth: number,
+): number {
+  const otherColumnsMinWidth = columns
+    .filter((c) => c.id !== columnId)
+    .reduce((sum, c) => sum + c.minWidth, 0);
+  return Math.max(COMMIT_TABLE_MIN_WIDTHS[columnId], containerWidth - otherColumnsMinWidth);
+}
+
 function sanitizeOrder(order: CommitTableLayout['order']): CommitTableColumnId[] {
   const seen = new Set<CommitTableColumnId>();
   const sanitized: CommitTableColumnId[] = ['graph'];

--- a/webview-ui/src/utils/commitTableLayout.ts
+++ b/webview-ui/src/utils/commitTableLayout.ts
@@ -124,6 +124,49 @@ export function setCommitTableColumnPreferredWidth(
   return nextLayout;
 }
 
+export function materializeCommitTableEffectiveWidths(
+  layout: CommitTableLayout,
+  columns: ResolvedCommitTableColumn[]
+): CommitTableLayout {
+  const nextLayout = cloneCommitTableLayout(layout);
+  for (const column of columns) {
+    nextLayout.columns[column.id].preferredWidth = Math.max(
+      COMMIT_TABLE_MIN_WIDTHS[column.id],
+      Math.round(column.effectiveWidth)
+    );
+  }
+  return nextLayout;
+}
+
+export function resizeCommitTableColumnPair({
+  layout,
+  leftColumnId,
+  rightColumnId,
+  leftStartWidth,
+  rightStartWidth,
+  deltaX,
+}: {
+  layout: CommitTableLayout;
+  leftColumnId: CommitTableColumnId;
+  rightColumnId: CommitTableColumnId;
+  leftStartWidth: number;
+  rightStartWidth: number;
+  deltaX: number;
+}): CommitTableLayout {
+  const maxLeftShrink = leftStartWidth - COMMIT_TABLE_MIN_WIDTHS[leftColumnId];
+  const maxRightShrink = rightStartWidth - COMMIT_TABLE_MIN_WIDTHS[rightColumnId];
+  const clampedDelta = Math.min(maxRightShrink, Math.max(-maxLeftShrink, deltaX));
+  return setCommitTableColumnPreferredWidth(
+    setCommitTableColumnPreferredWidth(
+      layout,
+      leftColumnId,
+      leftStartWidth + clampedDelta
+    ),
+    rightColumnId,
+    rightStartWidth - clampedDelta
+  );
+}
+
 export function setCommitTableColumnVisibility(
   layout: CommitTableLayout,
   columnId: CommitTableColumnId,


### PR DESCRIPTION
Hi @onlineeric, I found a new bug after my last PR.
Below are messages generated by AI:

## Why

The commit table can currently get into a bad layout state that is hard to recover from.

The clearest failure case is column resizing. If a user drags one separator (the Hash column) too far, one column can grow large enough to consume almost the entire table width. The other columns are then pushed out of view, so the user may no longer be able to reach the separators needed to fix the layout.

This is worse because column widths are persisted. Once an oversized width is saved into VS Code global state, refreshing or restarting VS Code does not help. The extension restores the same broken layout on the next load.

This PR tries to make that failure mode much less likely and gives users a way back if it still happens.

<img width="5344" height="2898" alt="hash" src="https://github.com/user-attachments/assets/422553e4-a3ec-4de8-afb1-32bf293310d1" />

## What This Improves

Column resizing now has a practical upper bound. A column should no longer be allowed to grow so wide that the other visible columns cannot keep at least their minimum usable width.

Persisted layouts are also treated more defensively. If an oversized width was already saved, the extension clamps it while loading the stored table layout instead of blindly restoring the broken value.

There is also now a “Reset column widths to defaults” action in the table settings UI. This gives users an obvious recovery path without needing to manually clear VS Code global state.

## About The Author Column Bug

This work started while investigating a separate bug around the Author and Date columns.

The remaining bug is:

> When all columns are squeezed left and Date is the widest column, dragging the left edge of Author still does not reliably adjust Author width.

I tried several approaches to fix that interaction, but I have not found a complete fix yet. The hard part is that the Message column has special behavior: it absorbs extra space and shrinks first when the table gets tight. That makes separators after Message behave differently from normal table column boundaries.

This PR does not claim to fully fix that Author-left-edge bug. It keeps the part of the work that made resizing safer and more recoverable, and leaves the remaining Author/Date interaction for a follow-up.