### PR TITLE
Limit graph traversal to supported Git ref types

### DIFF
--- a/src/__tests__/GitLogService.test.ts
+++ b/src/__tests__/GitLogService.test.ts
@@ -26,7 +26,7 @@ describe('GitLogService.getCommits', () => {
     }));
   });
 
-  it('uses --all with stash exclusion when no branch filter is active', async () => {
+  it('uses HEAD and user-facing ref namespaces when no branch filter is active', async () => {
     const service = new GitLogService('/repo', mockLog);
     const executeSpy = vi.spyOn(service['executor'], 'execute')
       .mockResolvedValue({ success: true, value: { stdout: '', stderr: '' } });
@@ -40,10 +40,25 @@ describe('GitLogService.getCommits', () => {
         '--max-count=25',
         '--format=%H%x00%h%x00%P%x00%an%x00%ae%x00%at%x00%s%x00%D',
         '--date-order',
-        '--exclude=refs/stash',
-        '--all',
+        'HEAD',
+        '--branches',
+        '--remotes',
+        '--tags',
         '--',
       ],
+    }));
+  });
+
+  it('fetches authors from user-facing ref namespaces', async () => {
+    const service = new GitLogService('/repo', mockLog);
+    const executeSpy = vi.spyOn(service['executor'], 'execute')
+      .mockResolvedValue({ success: true, value: { stdout: '', stderr: '' } });
+
+    const result = await service.getAuthors();
+
+    expect(result.success).toBe(true);
+    expect(executeSpy).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['log', 'HEAD', '--branches', '--remotes', '--tags', '--format=%an%x00%ae'],
     }));
   });
 });

--- a/src/__tests__/gitParsers.test.ts
+++ b/src/__tests__/gitParsers.test.ts
@@ -90,6 +90,18 @@ describe('parseRefs', () => {
     expect(parseRefs('tag: v1.2.3')).toEqual([{ type: 'tag', name: 'v1.2.3' }]);
   });
 
+  it('parses fully-qualified standard refs', () => {
+    expect(parseRefs('refs/heads/feature/login, refs/remotes/my-fork/main, refs/tags/v2.0')).toEqual([
+      { type: 'branch', name: 'feature/login' },
+      { type: 'remote', remote: 'my-fork', name: 'main' },
+      { type: 'tag', name: 'v2.0' },
+    ]);
+  });
+
+  it('drops fully-qualified refs outside the supported graph ref types', () => {
+    expect(parseRefs('refs/jj/keep/abc123, refs/notes/commits, refs/replace/abc123')).toEqual([]);
+  });
+
   it('parses stash refs', () => {
     expect(parseRefs('refs/stash')).toEqual([{ type: 'stash', name: 'refs/stash' }]);
     expect(parseRefs('stash@{0}')).toEqual([{ type: 'stash', name: 'stash@{0}' }]);

--- a/src/services/GitLogService.ts
+++ b/src/services/GitLogService.ts
@@ -47,15 +47,16 @@ export class GitLogService {
       args.push(`--before=${filters.beforeDate}`);
     }
 
-    // Add branch filter(s) or --all flag after options so refs are parsed as revisions.
+    // Add branch filter(s) or default ref namespaces after options so refs are parsed as revisions.
     if (filters?.branches && filters.branches.length > 0) {
       revisionArgs.push(...filters.branches);
     } else {
-      // Exclude stash refs — stashes are fetched separately via GitStashService
-      // and merged into the graph by the frontend. Without this exclusion,
-      // stash internal commits (index, untracked) pollute the graph and the
-      // latest stash appears as a duplicate merge node.
-      args.push('--exclude=refs/stash', '--all');
+      // Show user-facing Git history only. `--all` also includes tool-owned
+      // namespaces such as refs/jj/keep/*, which can surface internal commits
+      // as blank side branches in the graph. Include HEAD explicitly so a
+      // detached checkout remains visible even when no branch/tag names it.
+      // Stashes are fetched separately.
+      args.push('HEAD', '--branches', '--remotes', '--tags');
     }
 
     // Separate revisions from paths to avoid ambiguous argument errors
@@ -91,7 +92,7 @@ export class GitLogService {
   async getAuthors(): Promise<Result<Author[]>> {
     this.log.info('Fetching authors');
     const result = await this.executor.execute({
-      args: ['log', '--all', '--format=%an%x00%ae'],
+      args: ['log', 'HEAD', '--branches', '--remotes', '--tags', '--format=%an%x00%ae'],
       cwd: this.workspacePath,
     });
 

--- a/src/utils/gitParsers.ts
+++ b/src/utils/gitParsers.ts
@@ -67,6 +67,10 @@ function parseRefPart(part: string): RefInfo | null {
     return { name: tagName, type: 'tag' };
   }
 
+  if (part.startsWith('refs/')) {
+    return parseQualifiedRef(part);
+  }
+
   // Stash ref (e.g. "refs/stash") — should not normally appear since stash
   // refs are excluded from git log, but handle defensively.
   if (part === 'refs/stash' || part.startsWith('stash@{')) {
@@ -93,6 +97,34 @@ function parseRefPart(part: string): RefInfo | null {
 
   // Local branch (may contain slashes like "feature/login")
   return { name: part, type: 'branch' };
+}
+
+function parseQualifiedRef(refName: string): RefInfo | null {
+  if (refName.startsWith('refs/heads/')) {
+    return { name: refName.slice('refs/heads/'.length), type: 'branch' };
+  }
+
+  if (refName.startsWith('refs/remotes/')) {
+    const remoteRef = refName.slice('refs/remotes/'.length);
+    const slashIndex = remoteRef.indexOf('/');
+    if (slashIndex <= 0) return null;
+
+    const remote = remoteRef.slice(0, slashIndex);
+    const branchName = remoteRef.slice(slashIndex + 1);
+    if (!branchName || branchName === 'HEAD') return null;
+
+    return { name: branchName, type: 'remote', remote };
+  }
+
+  if (refName.startsWith('refs/tags/')) {
+    return { name: refName.slice('refs/tags/'.length), type: 'tag' };
+  }
+
+  if (refName === 'refs/stash') {
+    return { name: refName, type: 'stash' };
+  }
+
+  return null;
 }
 
 export function parseBranchLine(line: string): Branch | null {


### PR DESCRIPTION
## Summary

I have a repo that contains refs from another VCS called Jujutsu, which has created refs, causing the extension to show empty heads in the graph.

This PR limits Speedy Git’s default graph traversal to the ref types the extension actually supports and hardens ref decoration parsing so unknown `refs/*` namespaces are not mislabeled as branches.

### Before

<img width="3658" height="640" alt="before" src="https://github.com/user-attachments/assets/65d93f11-525e-4c12-a5a9-947f86a87d3c" />

### After

<img width="3668" height="794" alt="after" src="https://github.com/user-attachments/assets/509ab931-7fd4-49f5-86c9-3e729075d6c2" />

## Why

In my repository, opening the Speedy Git graph showed several blank side branches stemming from `main`. These were not reflog/lost commits. They came from Jujutsu internal refs under `refs/jj/keep/*`.

The old query used `git log --all`, which traverses every ref namespace, including tool-owned refs. Speedy Git’s UI model only supports HEAD, branches, remotes, tags, stashes, and the synthetic uncommitted node, so arbitrary refs had no correct display or action model.

## What Changed

- Replaced default `git log --all` traversal with:
  - `HEAD`
  - `--branches`
  - `--remotes`
  - `--tags`
- Included `HEAD` explicitly so detached checkouts remain visible.
- Kept stashes out of the main log traversal because they are fetched and displayed separately through the existing stash service.
- Updated author discovery to use the same supported ref set.
- Hardened fully-qualified ref parsing:
  - `refs/heads/*` maps to branch
  - `refs/remotes/*` maps to remote
  - `refs/tags/*` maps to tag
  - `refs/stash` maps to stash
  - other `refs/*` namespaces are ignored
- Added tests for the new query and parser behavior.

## Verification

- `pnpm test -- src/__tests__/GitLogService.test.ts src/__tests__/gitParsers.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run ext:package`