### PR TITLE
Add setting for customizing the status bar label

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
           "minimum": 1,
           "markdownDescription": "Number of commits to load per batch in the Git graph panel. Lower values give faster initial load; higher values reduce scroll-triggered fetches for large repositories."
         },
+        "speedyGit.statusBarText": {
+          "type": "string",
+          "default": "$(zap) Speedy Git",
+          "markdownDescription": "Text shown for the Speedy Git status bar item. Supports VS Code codicon syntax such as `$(zap)`."
+        },
         "speedyGit.graphColors": {
           "type": "array",
           "items": {

--- a/src/ExtensionController.ts
+++ b/src/ExtensionController.ts
@@ -75,7 +75,7 @@ export class ExtensionController {
 
     // Create status bar item
     const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
-    statusBar.text = '$(zap) Speedy Git';
+    statusBar.text = this.readStatusBarText();
     statusBar.tooltip = 'Open Speedy Git';
     statusBar.command = 'speedyGit.showGraph';
     this.statusBarItem = statusBar;
@@ -91,6 +91,7 @@ export class ExtensionController {
 
   private updateStatusBar() {
     if (!this.statusBarItem || !this.gitRepoDiscoveryService) return;
+    this.statusBarItem.text = this.readStatusBarText();
     const repos = this.gitRepoDiscoveryService.getRepos();
     if (repos.length === 0) {
       this.statusBarItem.hide();
@@ -149,11 +150,13 @@ export class ExtensionController {
   private registerSettingsListener() {
     this.context.subscriptions.push(
       vscode.workspace.onDidChangeConfiguration((event) => {
-        if (!this.didSpeedyGitSettingsChange(event)) {
-          return;
+        if (event.affectsConfiguration('speedyGit.statusBarText')) {
+          this.updateStatusBar();
         }
 
-        this.webviewProvider?.sendSettingsData(this.readUserSettings());
+        if (this.didSpeedyGitWebviewSettingsChange(event)) {
+          this.webviewProvider?.sendSettingsData(this.readUserSettings());
+        }
       })
     );
   }
@@ -306,7 +309,7 @@ export class ExtensionController {
       ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   }
 
-  private didSpeedyGitSettingsChange(event: vscode.ConfigurationChangeEvent): boolean {
+  private didSpeedyGitWebviewSettingsChange(event: vscode.ConfigurationChangeEvent): boolean {
     return [
       'speedyGit.graphColors',
       'speedyGit.dateFormat',
@@ -316,6 +319,11 @@ export class ExtensionController {
       'speedyGit.showTags',
       'speedyGit.batchCommitSize',
     ].some((section) => event.affectsConfiguration(section));
+  }
+
+  private readStatusBarText(): string {
+    const value = vscode.workspace.getConfiguration('speedyGit').get<string>('statusBarText');
+    return typeof value === 'string' ? value : '$(zap) Speedy Git';
   }
 
   private readUserSettings(): UserSettings {


### PR DESCRIPTION
## Summary

My VS Code status bar is crowded, so I want to keep the text simple.

This adds a new `speedyGit.statusBarText` configuration option for customizing the Speedy Git status bar item label.

The default remains `$(zap) Speedy Git`, so existing users see no change in behavior unless they set a custom value.

## Changes

- Added `speedyGit.statusBarText` to the extension configuration schema.
- Replaced the hard-coded status bar text with a config-backed value.
- Refreshes the status bar label immediately when the setting changes.
- Keeps webview settings updates scoped to settings that actually affect the webview.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm ext:package`

Manual installation verified.

<img width="266" height="60" alt="statusbar" src="https://github.com/user-attachments/assets/e830a0d3-bdd0-4a69-8e6f-9567dd9a29a7" />