### PR TITLE
Fix commit details author badge theme readability

### DIFF
--- a/webview-ui/src/components/AuthorBadge.tsx
+++ b/webview-ui/src/components/AuthorBadge.tsx
@@ -5,12 +5,28 @@ interface AuthorBadgeProps {
   email: string;
   onRemove?: () => void;
   className?: string;
+  inheritTextColor?: boolean;
+  showBorder?: boolean;
 }
 
-export function AuthorBadge({ name, email, onRemove, className }: AuthorBadgeProps) {
+export function AuthorBadge({
+  name,
+  email,
+  onRemove,
+  className,
+  inheritTextColor = false,
+  showBorder = true,
+}: AuthorBadgeProps) {
+  const textColorClass = inheritTextColor
+    ? 'text-inherit'
+    : 'text-[var(--vscode-badge-foreground)]';
+  const borderClass = showBorder
+    ? 'border border-[var(--vscode-badge-background)]'
+    : 'border border-transparent';
+
   return (
     <span
-      className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded border border-[var(--vscode-badge-background)] text-[var(--vscode-badge-foreground)] ${className ?? ''}`}
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded ${borderClass} ${textColorClass} ${className ?? ''}`}
     >
       <AuthorAvatar author={name} email={email} />
       <span className="truncate max-w-[120px]">{name}</span>

--- a/webview-ui/src/components/CommitDetailsPanel.tsx
+++ b/webview-ui/src/components/CommitDetailsPanel.tsx
@@ -485,7 +485,7 @@ function CommitMetadata({ details }: { details: CommitDetails }) {
       )}
       <div className="flex gap-2">
         <span className="w-16 flex-shrink-0 text-[var(--vscode-descriptionForeground)]">Author:</span>
-        <AuthorBadge name={details.author} email={details.authorEmail} />
+        <AuthorBadge name={details.author} email={details.authorEmail} inheritTextColor showBorder={false} />
       </div>
       <MetadataRow label="Date" value={formatRelativeDate(details.authorDate)} />
       {details.committer !== details.author && (


### PR DESCRIPTION
## Summary

- Use inherited text color for the commit details panel `Author:` row so the username remains readable across themes.
- Remove the visible frame around the commit details author badge.
- Preserve the existing bordered author chip styling in other UI areas, such as author filters.

### Before

<img width="838" height="290" alt="before" src="https://github.com/user-attachments/assets/620245da-4208-4542-88a0-876917c54be9" />

### After

<img width="834" height="304" alt="after" src="https://github.com/user-attachments/assets/85eb29e2-0224-464d-8104-9e0852d7855e" />

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`