### PR TITLE
Release version 4.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "speedy-git-ext" extension will be documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [4.3.4] - 2026-06-03
+
+### Fixed
+- The **Checkout Commit** confirmation dialog now shows the developer command preview (`git checkout <hash>`), matching the Checkout Branch dialog and every other operation dialog. Previously the dialog confirmed a detached-HEAD checkout without previewing the underlying git command.
+
 ## [4.3.3] - 2026-05-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speedy-git-ext",
   "displayName": "Speedy Git",
   "description": "A performance-first, lightweight Git graph visualization extension for VS Code",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "publisher": "onlineeric",
   "license": "MIT",
   "repository": {

--- a/webview-ui/src/components/CommitContextMenu.tsx
+++ b/webview-ui/src/components/CommitContextMenu.tsx
@@ -3,7 +3,7 @@ import * as ContextMenu from '@radix-ui/react-context-menu';
 import type { Commit, CherryPickOptions, ResetMode, RebaseEntry, CommitParentInfo, RevertOptions, SlotValue } from '@shared/types';
 import { rpcClient } from '../rpc/rpcClient';
 import { useGraphStore } from '../stores/graphStore';
-import { buildResetCommand } from '../utils/gitCommandBuilder';
+import { buildResetCommand, buildCheckoutCommand } from '../utils/gitCommandBuilder';
 import { ensureComparePanelOpen, setSlotsAndCompare } from '../utils/compareDispatch';
 import { slotsEqual } from '../utils/compareSlot';
 import { ConfirmDialog } from './ConfirmDialog';
@@ -434,6 +434,7 @@ export function CommitContextMenu({ commit, children }: CommitContextMenuProps) 
         onCancel={() => setCheckoutCommitConfirmOpen(false)}
         title="Checkout Commit"
         description={`Checkout commit ${commit.abbreviatedHash} will result in detached HEAD. Continue?`}
+        commandPreview={buildCheckoutCommand({ branch: commit.abbreviatedHash, pull: false })}
       />
 
       <CreateBranchDialog


### PR DESCRIPTION
- Updated the Checkout Commit confirmation dialog to display the developer command preview (`git checkout <hash>`), ensuring consistency with the Checkout Branch dialog and other operation dialogs.
- Bumped version number in package.json to 4.3.4.