### PR TITLE
Add unit tests for worktreeHandlers and utility functions

### DIFF
--- a/src/__tests__/worktreeHandlers.test.ts
+++ b/src/__tests__/worktreeHandlers.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import { worktreeHandlers } from '../webview/handlers/worktreeHandlers.js';
+import type { WebviewRequestContext } from '../webview/WebviewRequestContext.js';
+import { ok, err, GitError } from '../../shared/errors.js';
+
+interface WorktreeServiceMock {
+  addWorktree: ReturnType<typeof vi.fn>;
+  copyIgnoredEnvFilesTo: ReturnType<typeof vi.fn>;
+  detectCopyableEnvFiles: ReturnType<typeof vi.fn>;
+}
+
+function makeContext(gitWorktreeService: Partial<WorktreeServiceMock>) {
+  const postMessage = vi.fn();
+  const reload = vi.fn().mockResolvedValue(undefined);
+  const openWorktreeFolder = vi.fn().mockResolvedValue(undefined);
+  const context = {
+    services: { current: () => ({ gitWorktreeService }) },
+    postMessage,
+    refreshCoordinator: { reload },
+    editorCommands: { openWorktreeFolder },
+  } as unknown as WebviewRequestContext;
+  return { context, postMessage, reload, openWorktreeFolder };
+}
+
+function addWorktreeMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'addWorktree' as const,
+    payload: {
+      path: '/wt/feature',
+      ref: 'feature',
+      branchMode: 'existing' as const,
+      ...overrides,
+    },
+  };
+}
+
+describe('worktreeHandlers.addWorktree — env-file copy orchestration', () => {
+  it('does not copy env files when copyEnvFiles is not set', async () => {
+    const service: Partial<WorktreeServiceMock> = {
+      addWorktree: vi.fn().mockResolvedValue(ok(undefined)),
+      copyIgnoredEnvFilesTo: vi.fn(),
+    };
+    const { context, postMessage, reload, openWorktreeFolder } = makeContext(service);
+
+    await worktreeHandlers.addWorktree(addWorktreeMessage(), context);
+
+    expect(service.copyIgnoredEnvFilesTo).not.toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith({ type: 'success', payload: { message: 'Worktree created' } });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(openWorktreeFolder).toHaveBeenCalledWith('/wt/feature');
+  });
+
+  it('copies env files and reports plain success when nothing is skipped', async () => {
+    const service: Partial<WorktreeServiceMock> = {
+      addWorktree: vi.fn().mockResolvedValue(ok(undefined)),
+      copyIgnoredEnvFilesTo: vi.fn().mockResolvedValue(ok({ copied: ['.env'], skippedNotIgnored: [] })),
+    };
+    const { context, postMessage } = makeContext(service);
+
+    await worktreeHandlers.addWorktree(addWorktreeMessage({ copyEnvFiles: true }), context);
+
+    expect(service.copyIgnoredEnvFilesTo).toHaveBeenCalledWith('/wt/feature');
+    expect(postMessage).toHaveBeenCalledWith({ type: 'success', payload: { message: 'Worktree created' } });
+  });
+
+  it('surfaces a security-aware message when the target branch does not ignore some files', async () => {
+    const service: Partial<WorktreeServiceMock> = {
+      addWorktree: vi.fn().mockResolvedValue(ok(undefined)),
+      copyIgnoredEnvFilesTo: vi
+        .fn()
+        .mockResolvedValue(ok({ copied: ['.env'], skippedNotIgnored: ['.env.dev'] })),
+    };
+    const { context, postMessage } = makeContext(service);
+
+    await worktreeHandlers.addWorktree(addWorktreeMessage({ copyEnvFiles: true }), context);
+
+    const successCall = postMessage.mock.calls.find((c) => c[0].type === 'success');
+    expect(successCall?.[0].payload.message).toContain('.env.dev');
+    expect(successCall?.[0].payload.message).toMatch(/does not git-ignore/);
+  });
+
+  it('reports an error and skips copy/reload when worktree creation fails', async () => {
+    const service: Partial<WorktreeServiceMock> = {
+      addWorktree: vi.fn().mockResolvedValue(err(new GitError('boom', 'COMMAND_FAILED'))),
+      copyIgnoredEnvFilesTo: vi.fn(),
+    };
+    const { context, postMessage, reload, openWorktreeFolder } = makeContext(service);
+
+    await worktreeHandlers.addWorktree(addWorktreeMessage({ copyEnvFiles: true }), context);
+
+    expect(service.copyIgnoredEnvFilesTo).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+    expect(openWorktreeFolder).not.toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'error',
+      payload: { error: expect.objectContaining({ message: 'boom' }) },
+    });
+  });
+});
+
+describe('worktreeHandlers.getWorktreeEnvFiles', () => {
+  it('posts the detected ignored env files on success', async () => {
+    const service: Partial<WorktreeServiceMock> = {
+      detectCopyableEnvFiles: vi
+        .fn()
+        .mockResolvedValue(ok({ ignoredEnvFiles: ['.env', '.env.local'], envFilesPresent: true })),
+    };
+    const { context, postMessage } = makeContext(service);
+
+    await worktreeHandlers.getWorktreeEnvFiles(
+      { type: 'getWorktreeEnvFiles', payload: { requestId: 1 } },
+      context,
+    );
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'worktreeEnvFiles',
+      payload: { requestId: 1, ignoredEnvFiles: ['.env', '.env.local'], envFilesPresent: true },
+    });
+  });
+
+  it('posts safe defaults when detection fails', async () => {
+    const service: Partial<WorktreeServiceMock> = {
+      detectCopyableEnvFiles: vi.fn().mockResolvedValue(err(new GitError('nope', 'COMMAND_FAILED'))),
+    };
+    const { context, postMessage } = makeContext(service);
+
+    await worktreeHandlers.getWorktreeEnvFiles(
+      { type: 'getWorktreeEnvFiles', payload: { requestId: 2 } },
+      context,
+    );
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'worktreeEnvFiles',
+      payload: { requestId: 2, ignoredEnvFiles: [], envFilesPresent: false },
+    });
+  });
+});

--- a/webview-ui/src/utils/__tests__/compareMarker.test.ts
+++ b/webview-ui/src/utils/__tests__/compareMarker.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import type { Commit, RefInfo, SlotValue } from '@shared/types';
+import { slotMatchesCommitRow } from '../compareMarker';
+
+function commit(refs: RefInfo[], hash = 'abc123'): Commit {
+  return {
+    hash,
+    abbreviatedHash: hash.slice(0, 7),
+    parents: [],
+    author: 'Dev',
+    authorEmail: 'dev@test',
+    authorDate: 0,
+    subject: 'subject',
+    refs,
+  };
+}
+
+describe('slotMatchesCommitRow', () => {
+  it('returns false for a null slot', () => {
+    expect(slotMatchesCommitRow(null, commit([]))).toBe(false);
+  });
+
+  it('matches a commit slot by exact hash', () => {
+    const slot: SlotValue = { kind: 'commit', hash: 'abc123' };
+    expect(slotMatchesCommitRow(slot, commit([], 'abc123'))).toBe(true);
+    expect(slotMatchesCommitRow(slot, commit([], 'def456'))).toBe(false);
+  });
+
+  describe('branch slot', () => {
+    it('matches a local branch ref of the same name', () => {
+      const slot: SlotValue = { kind: 'branch', name: 'main' };
+      expect(slotMatchesCommitRow(slot, commit([{ name: 'main', type: 'branch' }]))).toBe(true);
+    });
+
+    it('does not match a remote ref when the slot is a local branch', () => {
+      const slot: SlotValue = { kind: 'branch', name: 'main' };
+      expect(
+        slotMatchesCommitRow(slot, commit([{ name: 'main', type: 'remote', remote: 'origin' }]))
+      ).toBe(false);
+    });
+
+    it('matches a remote branch ref by name and remote', () => {
+      const slot: SlotValue = { kind: 'branch', name: 'main', remote: 'origin' };
+      expect(
+        slotMatchesCommitRow(slot, commit([{ name: 'main', type: 'remote', remote: 'origin' }]))
+      ).toBe(true);
+    });
+
+    it('does not match a remote branch from a different remote', () => {
+      const slot: SlotValue = { kind: 'branch', name: 'main', remote: 'origin' };
+      expect(
+        slotMatchesCommitRow(slot, commit([{ name: 'main', type: 'remote', remote: 'upstream' }]))
+      ).toBe(false);
+    });
+
+    it('does not match when the branch name differs', () => {
+      const slot: SlotValue = { kind: 'branch', name: 'main' };
+      expect(slotMatchesCommitRow(slot, commit([{ name: 'dev', type: 'branch' }]))).toBe(false);
+    });
+  });
+
+  it('matches a tag slot against a tag ref of the same name', () => {
+    const slot: SlotValue = { kind: 'tag', name: 'v1' };
+    expect(slotMatchesCommitRow(slot, commit([{ name: 'v1', type: 'tag' }]))).toBe(true);
+    expect(slotMatchesCommitRow(slot, commit([{ name: 'v2', type: 'tag' }]))).toBe(false);
+  });
+
+  it('matches a head slot against a row carrying the HEAD pointer', () => {
+    const slot: SlotValue = { kind: 'head' };
+    expect(slotMatchesCommitRow(slot, commit([{ name: 'HEAD', type: 'head' }]))).toBe(true);
+    expect(slotMatchesCommitRow(slot, commit([{ name: 'main', type: 'branch' }]))).toBe(false);
+  });
+
+  it('never matches workingTree, expression, or emptyTree slots', () => {
+    const row = commit([{ name: 'main', type: 'branch' }], 'abc123');
+    expect(slotMatchesCommitRow({ kind: 'workingTree' }, row)).toBe(false);
+    expect(slotMatchesCommitRow({ kind: 'expression', text: 'abc123' }, row)).toBe(false);
+    expect(slotMatchesCommitRow({ kind: 'emptyTree' }, row)).toBe(false);
+  });
+});

--- a/webview-ui/src/utils/__tests__/compareSlot.test.ts
+++ b/webview-ui/src/utils/__tests__/compareSlot.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import type { SlotValue } from '@shared/types';
+import { slotsEqual, slotLabel } from '../compareSlot';
+
+describe('slotsEqual', () => {
+  it('treats two nulls as equal and null vs value as unequal', () => {
+    expect(slotsEqual(null, null)).toBe(true);
+    expect(slotsEqual(null, { kind: 'head' })).toBe(false);
+    expect(slotsEqual({ kind: 'head' }, null)).toBe(false);
+  });
+
+  it('returns true for the same reference', () => {
+    const v: SlotValue = { kind: 'commit', hash: 'abc' };
+    expect(slotsEqual(v, v)).toBe(true);
+  });
+
+  it('returns false when kinds differ', () => {
+    expect(slotsEqual({ kind: 'head' }, { kind: 'workingTree' })).toBe(false);
+  });
+
+  it('treats singleton kinds as equal regardless of identity', () => {
+    expect(slotsEqual({ kind: 'head' }, { kind: 'head' })).toBe(true);
+    expect(slotsEqual({ kind: 'workingTree' }, { kind: 'workingTree' })).toBe(true);
+    expect(slotsEqual({ kind: 'emptyTree' }, { kind: 'emptyTree' })).toBe(true);
+  });
+
+  it('compares branch name and remote (treating undefined remote as null)', () => {
+    expect(slotsEqual({ kind: 'branch', name: 'main' }, { kind: 'branch', name: 'main' })).toBe(true);
+    expect(
+      slotsEqual({ kind: 'branch', name: 'main' }, { kind: 'branch', name: 'main', remote: undefined })
+    ).toBe(true);
+    expect(
+      slotsEqual({ kind: 'branch', name: 'main', remote: 'origin' }, { kind: 'branch', name: 'main' })
+    ).toBe(false);
+    expect(
+      slotsEqual(
+        { kind: 'branch', name: 'main', remote: 'origin' },
+        { kind: 'branch', name: 'main', remote: 'upstream' }
+      )
+    ).toBe(false);
+    expect(
+      slotsEqual({ kind: 'branch', name: 'main' }, { kind: 'branch', name: 'dev' })
+    ).toBe(false);
+  });
+
+  it('compares tag names', () => {
+    expect(slotsEqual({ kind: 'tag', name: 'v1' }, { kind: 'tag', name: 'v1' })).toBe(true);
+    expect(slotsEqual({ kind: 'tag', name: 'v1' }, { kind: 'tag', name: 'v2' })).toBe(false);
+  });
+
+  it('compares commit hashes case-insensitively', () => {
+    expect(slotsEqual({ kind: 'commit', hash: 'ABC123' }, { kind: 'commit', hash: 'abc123' })).toBe(true);
+    expect(slotsEqual({ kind: 'commit', hash: 'abc' }, { kind: 'commit', hash: 'def' })).toBe(false);
+  });
+
+  it('compares expressions after trimming', () => {
+    expect(slotsEqual({ kind: 'expression', text: 'HEAD~1' }, { kind: 'expression', text: '  HEAD~1 ' })).toBe(true);
+    expect(slotsEqual({ kind: 'expression', text: 'HEAD~1' }, { kind: 'expression', text: 'HEAD~2' })).toBe(false);
+  });
+});
+
+describe('slotLabel', () => {
+  it('labels singleton kinds', () => {
+    expect(slotLabel({ kind: 'workingTree' })).toBe('Working Tree');
+    expect(slotLabel({ kind: 'head' })).toBe('HEAD');
+    expect(slotLabel({ kind: 'emptyTree' })).toBe('Empty Tree');
+  });
+
+  it('labels a local branch by name and a remote branch as remote/name', () => {
+    expect(slotLabel({ kind: 'branch', name: 'main' })).toBe('main');
+    expect(slotLabel({ kind: 'branch', name: 'main', remote: 'origin' })).toBe('origin/main');
+  });
+
+  it('labels a tag by name', () => {
+    expect(slotLabel({ kind: 'tag', name: 'v1.2.3' })).toBe('v1.2.3');
+  });
+
+  it('labels a commit with its 7-char short hash', () => {
+    expect(slotLabel({ kind: 'commit', hash: '0123456789abcdef' })).toBe('0123456');
+  });
+
+  it('labels an expression with its raw text', () => {
+    expect(slotLabel({ kind: 'expression', text: 'origin/main^2' })).toBe('origin/main^2');
+  });
+});

--- a/webview-ui/src/utils/__tests__/externalRefParser.test.ts
+++ b/webview-ui/src/utils/__tests__/externalRefParser.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseExternalRefs } from '../externalRefParser';
+
+const REPO = { owner: 'acme', repo: 'widgets' };
+
+describe('parseExternalRefs — PR/issue references', () => {
+  it('extracts a #123 reference and builds a GitHub URL when repo is known', () => {
+    const refs = parseExternalRefs('Fix crash #123', REPO);
+    expect(refs).toEqual([
+      {
+        label: '#123',
+        url: 'https://github.com/acme/widgets/issues/123',
+        type: 'pr-or-issue',
+      },
+    ]);
+  });
+
+  it('leaves url null when the GitHub owner/repo is unknown', () => {
+    const refs = parseExternalRefs('Fix crash #123', null);
+    expect(refs).toEqual([{ label: '#123', url: null, type: 'pr-or-issue' }]);
+  });
+
+  it('matches a reference at the start of the subject', () => {
+    const refs = parseExternalRefs('#7 initial commit', REPO);
+    expect(refs.map((r) => r.label)).toEqual(['#7']);
+  });
+
+  it('captures multiple distinct references', () => {
+    const refs = parseExternalRefs('Merge #1 and #2', REPO);
+    expect(refs.map((r) => r.label)).toEqual(['#1', '#2']);
+  });
+
+  it('deduplicates a repeated reference', () => {
+    const refs = parseExternalRefs('Revert #5, re-do #5', REPO);
+    expect(refs.filter((r) => r.type === 'pr-or-issue').map((r) => r.label)).toEqual(['#5']);
+  });
+
+  it('does not match a # inside a URL path (e.g. hex fragment after a slash)', () => {
+    const refs = parseExternalRefs('See http://x.test/page#42 for details', REPO);
+    expect(refs.filter((r) => r.type === 'pr-or-issue')).toHaveLength(0);
+  });
+
+  it('ignores a bare # with no number', () => {
+    expect(parseExternalRefs('a # b', REPO)).toEqual([]);
+  });
+});
+
+describe('parseExternalRefs — JIRA references', () => {
+  it('extracts a PROJECT-123 style reference with a null url', () => {
+    const refs = parseExternalRefs('PROJ-42 implement feature', REPO);
+    expect(refs).toEqual([{ label: 'PROJ-42', url: null, type: 'jira' }]);
+  });
+
+  it('captures multiple JIRA keys', () => {
+    const refs = parseExternalRefs('ABC-1 and DEF-22 done', REPO);
+    expect(refs.map((r) => r.label)).toEqual(['ABC-1', 'DEF-22']);
+  });
+
+  it('does not treat a lowercase prefix as a JIRA key', () => {
+    expect(parseExternalRefs('abc-1 nope', REPO)).toEqual([]);
+  });
+
+  it('deduplicates a repeated JIRA key', () => {
+    const refs = parseExternalRefs('PROJ-7 then PROJ-7 again', REPO);
+    expect(refs).toEqual([{ label: 'PROJ-7', url: null, type: 'jira' }]);
+  });
+});
+
+describe('parseExternalRefs — mixed and empty inputs', () => {
+  it('returns both a PR ref and a JIRA ref from one subject', () => {
+    const refs = parseExternalRefs('PROJ-9: fix #3', REPO);
+    expect(refs).toEqual([
+      { label: '#3', url: 'https://github.com/acme/widgets/issues/3', type: 'pr-or-issue' },
+      { label: 'PROJ-9', url: null, type: 'jira' },
+    ]);
+  });
+
+  it('returns an empty array when there are no references', () => {
+    expect(parseExternalRefs('just a normal commit message', REPO)).toEqual([]);
+  });
+});

--- a/webview-ui/src/utils/__tests__/formatDate.test.ts
+++ b/webview-ui/src/utils/__tests__/formatDate.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  formatRelativeDate,
+  formatAbsoluteDateTime,
+  formatAbsoluteDate,
+  getDateFormatter,
+} from '../formatDate';
+
+// Build a timestamp from local-time components so the absolute formatters
+// (which read getFullYear/getMonth/... in local time) assert deterministically
+// regardless of the machine's timezone.
+function localTs(year: number, month1: number, day: number, h = 0, m = 0): number {
+  return new Date(year, month1 - 1, day, h, m).getTime();
+}
+
+describe('formatRelativeDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-21T12:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const now = () => Date.now();
+
+  it('returns "just now" under a minute', () => {
+    expect(formatRelativeDate(now() - 30 * 1000)).toBe('just now');
+  });
+
+  it('formats minutes', () => {
+    expect(formatRelativeDate(now() - 5 * 60 * 1000)).toBe('5m ago');
+  });
+
+  it('formats hours', () => {
+    expect(formatRelativeDate(now() - 3 * 60 * 60 * 1000)).toBe('3h ago');
+  });
+
+  it('formats days', () => {
+    expect(formatRelativeDate(now() - 2 * 24 * 60 * 60 * 1000)).toBe('2d ago');
+  });
+
+  it('formats weeks', () => {
+    expect(formatRelativeDate(now() - 14 * 24 * 60 * 60 * 1000)).toBe('2w ago');
+  });
+
+  it('formats months', () => {
+    expect(formatRelativeDate(now() - 60 * 24 * 60 * 60 * 1000)).toBe('2mo ago');
+  });
+
+  it('formats years', () => {
+    expect(formatRelativeDate(now() - 800 * 24 * 60 * 60 * 1000)).toBe('2y ago');
+  });
+
+  it('uses floor at boundaries (59s is still "just now")', () => {
+    expect(formatRelativeDate(now() - 59 * 1000)).toBe('just now');
+    expect(formatRelativeDate(now() - 60 * 1000)).toBe('1m ago');
+  });
+});
+
+describe('formatAbsoluteDateTime / formatAbsoluteDate', () => {
+  it('zero-pads month, day, hour, and minute', () => {
+    const ts = localTs(2023, 1, 5, 9, 4);
+    expect(formatAbsoluteDateTime(ts)).toBe('2023-01-05 09:04');
+    expect(formatAbsoluteDate(ts)).toBe('2023-01-05');
+  });
+
+  it('renders two-digit components without extra padding', () => {
+    const ts = localTs(2024, 12, 25, 23, 59);
+    expect(formatAbsoluteDateTime(ts)).toBe('2024-12-25 23:59');
+    expect(formatAbsoluteDate(ts)).toBe('2024-12-25');
+  });
+});
+
+describe('getDateFormatter', () => {
+  const ts = localTs(2023, 1, 5, 9, 4);
+
+  it('dispatches to the absolute date-time formatter', () => {
+    expect(getDateFormatter('absolute')(ts)).toBe('2023-01-05 09:04');
+  });
+
+  it('dispatches to the absolute date-only formatter', () => {
+    expect(getDateFormatter('absolute-date')(ts)).toBe('2023-01-05');
+  });
+
+  it('falls back to the relative formatter for an unknown format', () => {
+    // `relative` is the default branch.
+    expect(getDateFormatter('relative')).toBe(formatRelativeDate);
+  });
+
+  it('memoizes the formatter for an identical (format, token) pair', () => {
+    const a = getDateFormatter('custom', 'yyyy-MM-dd');
+    const b = getDateFormatter('custom', 'yyyy-MM-dd');
+    expect(a).toBe(b);
+  });
+
+  it('returns a different formatter when the token changes', () => {
+    const a = getDateFormatter('custom', 'yyyy');
+    const b = getDateFormatter('custom', 'yyyy-MM');
+    expect(a).not.toBe(b);
+  });
+
+  describe('custom token', () => {
+    it('formats with a valid date-fns token', () => {
+      expect(getDateFormatter('custom', 'yyyy/MM/dd')(ts)).toBe('2023/01/05');
+    });
+
+    it('trims surrounding whitespace before validating the token', () => {
+      expect(getDateFormatter('custom', '  yyyy-MM-dd  ')(ts)).toBe('2023-01-05');
+    });
+
+    it('falls back to relative formatting for an empty/whitespace token', () => {
+      expect(getDateFormatter('custom', '   ')).toBe(formatRelativeDate);
+    });
+
+    it('falls back to relative formatting for an invalid token', () => {
+      // `YYYY` is a protected week-year token; date-fns throws by default.
+      expect(getDateFormatter('custom', 'YYYY')).toBe(formatRelativeDate);
+    });
+  });
+});


### PR DESCRIPTION
- Introduced tests for `worktreeHandlers.addWorktree` to validate env-file copying behavior and error handling.
- Added tests for `worktreeHandlers.getWorktreeEnvFiles` to ensure correct detection and posting of ignored env files.
- Created tests for utility functions: `slotMatchesCommitRow`, `slotsEqual`, and `slotLabel` to verify slot comparison logic.
- Implemented tests for `parseExternalRefs` to check extraction of PR/JIRA references from commit messages.
- Added tests for date formatting functions to ensure correct output for relative and absolute date formats.