### PR TITLE
fix(table): never let the Graph column hide the other commit columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "speedy-git-ext" extension will be documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [5.1.4] - 2026-06-28
+
+### Fixed
+- **The commit table can no longer collapse to a graph-only view.** In Table mode, if a repository's saved layout had a Graph column wider than the current pane, the Graph column filled the entire visible width and pushed every other column — Hash, Message, Author, Date, and their header labels — past the table's clipped right edge, where they couldn't be reached (Table mode has no horizontal scrollbar). The list appeared to show only the Graph column, even though clicking a commit still opened its details normally. Because column widths are stored per repository, a single affected repo showed this while every other repo looked fine. The Graph column now shrinks as a last resort — only when every other column is already at its minimum width and the table still overflows — so the other columns always stay visible. Existing layouts self-correct on load (no reset needed); previously the only workaround was **"Reset column widths to defaults"**.
+
 ## [5.1.3] - 2026-06-27
 
 ### Performance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speedy-git-ext",
   "displayName": "Speedy Git",
   "description": "A performance-first, lightweight Git graph visualization extension for VS Code",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "publisher": "onlineeric",
   "license": "MIT",
   "repository": {

--- a/webview-ui/src/utils/__tests__/commitTableLayout.test.ts
+++ b/webview-ui/src/utils/__tests__/commitTableLayout.test.ts
@@ -214,6 +214,28 @@ describe('resolveCommitTableLayout', () => {
     expect(hash.effectiveWidth).toBe(hash.minWidth);
   });
 
+  it('shrinks an oversized graph column so the others never get hidden', () => {
+    // Regression: a graph preferredWidth wider than the pane must not push the
+    // other columns past table mode's clipped (non-scrollable) right edge.
+    const layout = setCommitTableColumnPreferredWidth(
+      createDefaultCommitTableLayout(),
+      'graph',
+      5000,
+    );
+    const containerWidth = 800; // comfortably above the sum of all min widths
+    const resolved = resolveCommitTableLayout({ layout, containerWidth });
+
+    const graph = resolved.columns.find((c) => c.id === 'graph')!;
+    expect(graph.effectiveWidth).toBeLessThan(5000);
+
+    // Every column still gets at least its minimum width, and the whole table
+    // fits within the pane — so nothing is clipped out of view.
+    for (const col of resolved.columns) {
+      expect(col.effectiveWidth).toBeGreaterThanOrEqual(col.minWidth);
+    }
+    expect(resolved.tableWidth).toBeLessThanOrEqual(containerWidth);
+  });
+
   it('builds gridTemplateColumns string from effective widths', () => {
     const layout = createDefaultCommitTableLayout();
     const resolved = resolveCommitTableLayout({ layout, containerWidth: 9999 });

--- a/webview-ui/src/utils/commitTableLayout.ts
+++ b/webview-ui/src/utils/commitTableLayout.ts
@@ -273,6 +273,17 @@ export function resolveCommitTableLayout({
     }
   }
 
+  // Last resort: the graph column normally keeps its full preferred width, but
+  // if every other column is already at its minimum and the table still
+  // overflows, shrink graph too (down to its own minimum). Without this an
+  // oversized graph width — e.g. dragged wider than the pane, then viewed in a
+  // narrower pane — pushes every other column past the table's clipped right
+  // edge. Table mode has no horizontal scrollbar, so those columns (and their
+  // headers) become unreachable, leaving only the graph column visible.
+  if (remainingDeficit > 0) {
+    remainingDeficit = shrinkColumn(visibleColumns, 'graph', remainingDeficit);
+  }
+
   // Surplus space: expand the message column so the table spans the panel.
   if (containerWidth > 0) {
     const surplus = availableWidth - preferredTableWidth;


### PR DESCRIPTION
## Why this PR

When opening the commit graph for certain repos, the **table-mode** commit list rendered **only the Graph column** — no Hash / Message / Author / Date columns and not even their headers — while clicking a commit still opened the details panel normally. Other repos rendered fine, which made it look repo-specific.

It turned out the repo's data was irrelevant. The root cause is a layout-resolution gap:

- `resolveCommitTableLayout` shrinks columns to fit a tight pane in the order `message → author → date → hash`, but the **Graph column was never in the shrink set** — it always kept its full width.
- Table mode's list **and** header containers use `overflow-x: hidden`, so there is **no horizontal scrollbar** (classic mode uses `overflow: auto` and can scroll).
- Column widths are persisted **per repo** (`globalState` key `speedyGit.repoTableLayout.<hash>`).

So if a repo's saved layout had a Graph width wider than the current pane — e.g. the Graph/Hash divider was dragged wider, or a width was set while the window was wide and the graph was later viewed in a narrower pane — the Graph column filled the entire visible width and pushed every other column (and its header) past the clipped right edge, where they were unreachable. The details panel kept working because it fetches commit data independently of the list.

Clicking **"Reset column widths to defaults"** restored the view by returning Graph to 120px, which confirmed this was purely a width/layout issue and not corrupted data.

## How it's fixed

`resolveCommitTableLayout` now shrinks the Graph column **as a last resort** — only after `message`, `author`, `date`, and `hash` have all reached their minimum widths and the table still overflows the pane:

```ts
// after shrinking message → author → date → hash:
if (remainingDeficit > 0) {
  remainingDeficit = shrinkColumn(visibleColumns, 'graph', remainingDeficit);
}
```

- **Normal layouts are unaffected** — Graph keeps its full preferred width whenever there's room, and surplus still flows to the `message` column.
- **Under width pressure**, Graph can now shrink (down to its own minimum) so the other columns always retain at least their minimum widths and stay visible.
- Added a regression test asserting that an oversized Graph width (5000px in an 800px pane) is clamped so every column keeps ≥ its minimum width and the table fits the pane.

## Testing

- `pnpm build` — esbuild + `tsc --noEmit` + Vite all pass
- `pnpm test` — **695/695** tests pass across 59 files, including the new regression case
- Verified against the repository that originally reproduced the graph-only view

## What to expect going forward

- The "graph-only" state can no longer occur for any pane at least as wide as the sum of the column minimum widths (~468px).
- **No migration needed.** Existing persisted layouts with an oversized Graph width are self-correcting at render time. The stored preference is preserved as-is; only the *rendered* width is clamped, so nothing is silently rewritten.
- **Known edge case (not addressed here):** for panes narrower than ~468px, columns can still be clipped because table mode has no horizontal scrollbar. Fully covering that would mean adding horizontal scroll to table mode, which is a larger change — the header is a separate element outside the scroll container, so its scroll position would need to be synced with the body. Happy to do that as a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
