### PR TITLE
Update CHANGELOG for version 5.2.1 and enhance Git ref name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "speedy-git-ext" extension will be documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [5.2.1] - 2026-07-02
+
+### Changed
+- **Branch and remote names are now validated as you type, like tag names.** The Create Tag dialog's live git refname validation (introduced in 5.2.0) now also covers every other dialog that creates or renames a ref: **Create Branch**, **Rename Branch**, the new-branch name in **Create Worktree**, and the remote name in **Manage Remotes**. Invalid names (spaces, `..`, `~`, `^`, `:`, a trailing `.lock`, a leading `-`, etc.) show a specific error under the input and disable the confirm button, instead of letting the operation run and surfacing a raw git error afterwards. Branch names also reject the reserved name `HEAD`.
+
+### Internal
+- Generalized the shared tag-name validator into a ref-name validator with tag/branch/remote wrappers, and applied the same full refname rules to the backend creation paths (`git branch`, `git branch -m`, `git worktree add -b`, `git remote add`) for defense in depth.
+
 ## [5.2.0] - 2026-07-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speedy-git-ext",
   "displayName": "Speedy Git",
   "description": "A performance-first, lightweight Git graph visualization extension for VS Code",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "publisher": "onlineeric",
   "license": "MIT",
   "repository": {

--- a/shared/gitRefValidation.ts
+++ b/shared/gitRefValidation.ts
@@ -5,39 +5,61 @@ export interface GitRefNameValidation {
 
 const INVALID_REF_CHARS = new Set(['~', '^', ':', '?', '*', '[', '\\']);
 
-export function validateGitTagName(rawName: string): GitRefNameValidation {
+/**
+ * Validates a git ref name against `git check-ref-format` rules.
+ * `label` is used in error messages (e.g. "Tag name", "Branch name").
+ */
+export function validateGitRefName(rawName: string, label: string): GitRefNameValidation {
   const name = rawName.trim();
 
-  if (!name) return invalid('Tag name is required');
-  if (name.startsWith('-')) return invalid('Tag name cannot start with -');
-  if (name === '@') return invalid('Tag name cannot be @');
+  if (!name) return invalid(`${label} is required`);
+  if (name.startsWith('-')) return invalid(`${label} cannot start with -`);
+  if (name === '@') return invalid(`${label} cannot be @`);
   if (name.startsWith('/') || name.endsWith('/') || name.includes('//')) {
-    return invalid('Tag name cannot start, end, or contain empty slash segments');
+    return invalid(`${label} cannot start, end, or contain empty slash segments`);
   }
-  if (name.endsWith('.')) return invalid('Tag name cannot end with .');
-  if (name.includes('..')) return invalid('Tag name cannot contain ..');
-  if (name.includes('@{')) return invalid('Tag name cannot contain @{');
+  if (name.endsWith('.')) return invalid(`${label} cannot end with .`);
+  if (name.includes('..')) return invalid(`${label} cannot contain ..`);
+  if (name.includes('@{')) return invalid(`${label} cannot contain @{`);
 
   for (const char of name) {
     const code = char.charCodeAt(0);
     if (code <= 32 || code === 127) {
-      return invalid('Tag name cannot contain spaces or control characters');
+      return invalid(`${label} cannot contain spaces or control characters`);
     }
     if (INVALID_REF_CHARS.has(char)) {
-      return invalid(`Tag name cannot contain ${char}`);
+      return invalid(`${label} cannot contain ${char}`);
     }
   }
 
   for (const component of name.split('/')) {
     if (component.startsWith('.')) {
-      return invalid('Tag name components cannot start with .');
+      return invalid(`${label} components cannot start with .`);
     }
     if (component.endsWith('.lock')) {
-      return invalid('Tag name components cannot end with .lock');
+      return invalid(`${label} components cannot end with .lock`);
     }
   }
 
   return { valid: true };
+}
+
+export function validateGitTagName(rawName: string): GitRefNameValidation {
+  return validateGitRefName(rawName, 'Tag name');
+}
+
+export function validateGitBranchName(rawName: string): GitRefNameValidation {
+  const result = validateGitRefName(rawName, 'Branch name');
+  if (!result.valid) return result;
+  // `git branch HEAD` is refused by git itself; a stray refs/heads/HEAD makes
+  // every subsequent ref lookup ambiguous.
+  if (rawName.trim() === 'HEAD') return invalid('Branch name cannot be HEAD');
+  return result;
+}
+
+/** Remote names are embedded in refspecs (refs/remotes/<name>/…), so the same refname rules apply. */
+export function validateGitRemoteName(rawName: string): GitRefNameValidation {
+  return validateGitRefName(rawName, 'Remote name');
 }
 
 function invalid(message: string): GitRefNameValidation {

--- a/src/__tests__/gitValidation.test.ts
+++ b/src/__tests__/gitValidation.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { validateFilePath, validateHash, validateRefName, validateTagName } from '../utils/gitValidation.js';
+import {
+  validateFilePath,
+  validateHash,
+  validateLocalBranchName,
+  validateRefName,
+  validateRemoteName,
+  validateTagName,
+} from '../utils/gitValidation.js';
 
 describe('validateHash', () => {
   it('accepts a 40-char SHA1 hash', () => {
@@ -101,6 +108,67 @@ describe('validateTagName', () => {
 
   it('rejects names starting with a dash to prevent flag injection', () => {
     expect(validateTagName('-v1.0.0').success).toBe(false);
+  });
+});
+
+describe('validateLocalBranchName', () => {
+  it('accepts ordinary and slash-containing branch names', () => {
+    expect(validateLocalBranchName('main').success).toBe(true);
+    expect(validateLocalBranchName('feature/login').success).toBe(true);
+    expect(validateLocalBranchName('release-1.0').success).toBe(true);
+  });
+
+  it('rejects the reserved name HEAD', () => {
+    expect(validateLocalBranchName('HEAD').success).toBe(false);
+  });
+
+  it('rejects git-invalid refname patterns', () => {
+    expect(validateLocalBranchName('feature branch').success).toBe(false);
+    expect(validateLocalBranchName('feature..branch').success).toBe(false);
+    expect(validateLocalBranchName('feature~1').success).toBe(false);
+    expect(validateLocalBranchName('feature^2').success).toBe(false);
+    expect(validateLocalBranchName('feature/.hidden').success).toBe(false);
+    expect(validateLocalBranchName('feature.lock').success).toBe(false);
+    expect(validateLocalBranchName('feature/').success).toBe(false);
+  });
+
+  it('rejects names starting with a dash to prevent flag injection', () => {
+    expect(validateLocalBranchName('-D').success).toBe(false);
+  });
+
+  it('returns VALIDATION_ERROR code on failure', () => {
+    const result = validateLocalBranchName('bad name');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns the trimmed name so git never receives edge whitespace', () => {
+    const result = validateLocalBranchName(' feature ');
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.value).toBe('feature');
+  });
+});
+
+describe('validateRemoteName', () => {
+  it('accepts ordinary remote names', () => {
+    expect(validateRemoteName('origin').success).toBe(true);
+    expect(validateRemoteName('upstream-fork').success).toBe(true);
+  });
+
+  it('rejects git-invalid refname patterns', () => {
+    expect(validateRemoteName('my remote').success).toBe(false);
+    expect(validateRemoteName('remote^1').success).toBe(false);
+    expect(validateRemoteName('remote..name').success).toBe(false);
+  });
+
+  it('rejects names starting with a dash to prevent flag injection', () => {
+    expect(validateRemoteName('--mirror').success).toBe(false);
+  });
+
+  it('returns the trimmed name so git never receives edge whitespace', () => {
+    const result = validateRemoteName(' origin ');
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.value).toBe('origin');
   });
 });
 

--- a/src/services/GitBranchService.ts
+++ b/src/services/GitBranchService.ts
@@ -166,7 +166,7 @@ export class GitBranchService {
       if (!startCheck.success) return startCheck;
     }
 
-    const args = ['branch', name];
+    const args = ['branch', nameCheck.value];
     if (startPoint) args.push(startPoint);
 
     const result = await this.executor.execute({ args, cwd: this.workspacePath });
@@ -182,7 +182,7 @@ export class GitBranchService {
     if (!newCheck.success) return newCheck;
 
     const result = await this.executor.execute({
-      args: ['branch', '-m', oldName, newName],
+      args: ['branch', '-m', oldName, newCheck.value],
       cwd: this.workspacePath,
     });
     if (!result.success) return result;

--- a/src/services/GitRemoteService.ts
+++ b/src/services/GitRemoteService.ts
@@ -2,7 +2,7 @@ import type { LogOutputChannel } from 'vscode';
 import { GitExecutor } from './GitExecutor.js';
 import { type Result, ok } from '../../shared/errors.js';
 import type { PushForceMode, RemoteInfo } from '../../shared/types.js';
-import { validateRefName } from '../utils/gitValidation.js';
+import { validateRefName, validateRemoteName } from '../utils/gitValidation.js';
 
 export class GitRemoteService {
   private executor: GitExecutor;
@@ -90,11 +90,11 @@ export class GitRemoteService {
 
   async addRemote(name: string, url: string): Promise<Result<string>> {
     this.log.info(`Add remote: ${name} → ${url}`);
-    const nameCheck = validateRefName(name);
+    const nameCheck = validateRemoteName(name);
     if (!nameCheck.success) return nameCheck;
 
     const result = await this.executor.execute({
-      args: ['remote', 'add', name, url],
+      args: ['remote', 'add', nameCheck.value, url],
       cwd: this.workspacePath,
     });
     if (!result.success) return result;

--- a/src/services/GitWorktreeService.ts
+++ b/src/services/GitWorktreeService.ts
@@ -6,7 +6,7 @@ import { GitExecutor } from './GitExecutor.js';
 import { GitError, type Result, ok, err } from '../../shared/errors.js';
 import type { WorktreeInfo, WorktreeBranchMode } from '../../shared/types.js';
 import { isDirtyWorkingTree } from '../utils/gitQueries.js';
-import { validateRefName, validateWorktreePath } from '../utils/gitValidation.js';
+import { validateLocalBranchName, validateRefName, validateWorktreePath } from '../utils/gitValidation.js';
 import { mapWorktreeConflictError } from '../utils/worktreeErrors.js';
 
 export interface AddWorktreeOptions {
@@ -285,9 +285,9 @@ export class GitWorktreeService {
 
     if (opts.branchMode === 'new') {
       const name = opts.newBranchName ?? '';
-      const nameCheck = validateRefName(name);
+      const nameCheck = validateLocalBranchName(name);
       if (!nameCheck.success) return nameCheck;
-      args.push('-b', name, pathCheck.value, opts.ref);
+      args.push('-b', nameCheck.value, pathCheck.value, opts.ref);
     } else if (opts.branchMode === 'detached') {
       args.push('--detach', pathCheck.value, opts.ref);
     } else {

--- a/src/utils/gitValidation.ts
+++ b/src/utils/gitValidation.ts
@@ -1,5 +1,10 @@
 import { GitError, type Result, err } from '../../shared/errors.js';
-import { validateGitTagName } from '../../shared/gitRefValidation.js';
+import {
+  type GitRefNameValidation,
+  validateGitBranchName,
+  validateGitRemoteName,
+  validateGitTagName,
+} from '../../shared/gitRefValidation.js';
 
 const HASH_WITH_PARENT_RE = /^[0-9a-f]{4,40}(~\d+)?$/i;
 
@@ -19,33 +24,35 @@ export function validateRefName(name: string): Result<string> {
   return { success: true, value: name };
 }
 
-/** Validates a tag name using git refname rules plus flag-injection protection. */
-export function validateTagName(name: string): Result<string> {
-  const validation = validateGitTagName(name);
+/** Converts a `GitRefNameValidation` result into the `Result<string>` shape used by git services. */
+function toRefNameResult(validation: GitRefNameValidation, name: string, label: string): Result<string> {
   if (!validation.valid) {
-    return err(new GitError(validation.message ?? `Invalid tag name: ${name}`, 'VALIDATION_ERROR'));
+    return err(new GitError(validation.message ?? `Invalid ${label}: ${name}`, 'VALIDATION_ERROR'));
   }
   return { success: true, value: name.trim() };
 }
 
-const RESERVED_LOCAL_BRANCH_NAMES = new Set(['HEAD']);
+/** Validates a tag name using git refname rules plus flag-injection protection. */
+export function validateTagName(name: string): Result<string> {
+  return toRefNameResult(validateGitTagName(name), name, 'tag name');
+}
 
 /**
  * Validates a name that will be used to create or update a local branch
  * (i.e. anything that ends up writing `refs/heads/<name>`).
  *
- * `git branch <name>` already refuses reserved names like "HEAD", but lower-level
- * refspecs such as `git fetch origin HEAD:HEAD` bypass that check and silently
- * create a stray `refs/heads/HEAD`, which then makes every subsequent ref lookup
- * ambiguous. Guard the call sites that can hit that path.
+ * Applies full git refname rules, including the reserved name "HEAD":
+ * `git branch HEAD` is refused by git itself, but lower-level refspecs such as
+ * `git fetch origin HEAD:HEAD` bypass that check and silently create a stray
+ * `refs/heads/HEAD`, which then makes every subsequent ref lookup ambiguous.
  */
 export function validateLocalBranchName(name: string): Result<string> {
-  const base = validateRefName(name);
-  if (!base.success) return base;
-  if (RESERVED_LOCAL_BRANCH_NAMES.has(name)) {
-    return err(new GitError(`'${name}' is reserved and cannot be used as a local branch name.`, 'VALIDATION_ERROR'));
-  }
-  return { success: true, value: name };
+  return toRefNameResult(validateGitBranchName(name), name, 'branch name');
+}
+
+/** Validates a name that will be used to create a new remote (`git remote add`). */
+export function validateRemoteName(name: string): Result<string> {
+  return toRefNameResult(validateGitRemoteName(name), name, 'remote name');
 }
 
 /** Validates a file path — rejects empty strings and values starting with '-'. */

--- a/webview-ui/src/components/BranchContextMenu.tsx
+++ b/webview-ui/src/components/BranchContextMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import * as ContextMenu from '@radix-ui/react-context-menu';
 import type { RefInfo, SlotValue } from '@shared/types';
+import { validateGitBranchName } from '@shared/gitRefValidation';
 import { rpcClient } from '../rpc/rpcClient';
 import { useGraphStore } from '../stores/graphStore';
 import {
@@ -450,7 +451,11 @@ function BranchContextMenuBody({ refInfo }: { refInfo: RefInfo }) {
         title="Rename Branch"
         label="New branch name"
         defaultValue={refInfo.name}
-        validate={(v) => v.startsWith('-') ? 'Branch name cannot start with -' : undefined}
+        validate={(v) =>
+          v === refInfo.name
+            ? 'New name is the same as the current name'
+            : validateGitBranchName(v).message
+        }
         buildCommandPreview={buildRenamePreview}
       />
 

--- a/webview-ui/src/components/CreateBranchDialog.tsx
+++ b/webview-ui/src/components/CreateBranchDialog.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import type { Commit } from '@shared/types';
+import { validateGitBranchName } from '@shared/gitRefValidation';
 import { rpcClient } from '../rpc/rpcClient';
 import { buildCreateBranchCommand } from '../utils/gitCommandBuilder';
+import { deriveRefNameField } from '../utils/refNameField';
 import { CommandPreview } from './CommandPreview';
+import { FieldError } from './FieldError';
 import { dialogContentClassName, dialogContentStyle } from './dialogStyles';
 
 interface CreateBranchDialogProps {
@@ -15,9 +18,9 @@ interface CreateBranchDialogProps {
 export function CreateBranchDialog({ open, commit, onClose }: CreateBranchDialogProps) {
   const [name, setName] = useState('');
   const [checkout, setCheckout] = useState(false);
-  const [nameError, setNameError] = useState<string | undefined>(undefined);
 
   const trimmedName = name.trim();
+  const { error: nameError, valid: canCreate } = deriveRefNameField(name, validateGitBranchName);
   const commandPreview = buildCreateBranchCommand({
     name: trimmedName || '<name>',
     startPoint: commit.abbreviatedHash,
@@ -27,17 +30,11 @@ export function CreateBranchDialog({ open, commit, onClose }: CreateBranchDialog
   const reset = () => {
     setName('');
     setCheckout(false);
-    setNameError(undefined);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!trimmedName) {
-      setNameError('Branch name is required');
-      return;
-    }
-    if (trimmedName.startsWith('-')) {
-      setNameError('Branch name cannot start with -');
+    if (!canCreate) {
       return;
     }
     rpcClient.createBranch(trimmedName, commit.hash, checkout);
@@ -71,17 +68,14 @@ export function CreateBranchDialog({ open, commit, onClose }: CreateBranchDialog
               <input
                 type="text"
                 value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                  setNameError(undefined);
-                }}
+                onChange={(e) => setName(e.target.value)}
                 placeholder="feature/my-branch"
                 autoFocus
+                aria-invalid={!!nameError}
+                aria-describedby={nameError ? 'branch-name-error' : undefined}
                 className="w-full px-2 py-1.5 text-sm rounded bg-[var(--vscode-input-background)] text-[var(--vscode-input-foreground)] border border-[var(--vscode-input-border)] focus:outline-none focus:border-[var(--vscode-focusBorder)]"
               />
-              {nameError && (
-                <p className="mt-1 text-xs text-[var(--vscode-errorForeground)]">{nameError}</p>
-              )}
+              <FieldError id="branch-name-error" message={nameError} />
             </div>
             <label className="flex items-center gap-2 cursor-pointer select-none">
               <input
@@ -106,7 +100,8 @@ export function CreateBranchDialog({ open, commit, onClose }: CreateBranchDialog
               </Dialog.Close>
               <button
                 type="submit"
-                className="px-3 py-1.5 text-sm rounded bg-[var(--vscode-button-background)] text-[var(--vscode-button-foreground)] hover:bg-[var(--vscode-button-hoverBackground)]"
+                disabled={!canCreate}
+                className="px-3 py-1.5 text-sm rounded bg-[var(--vscode-button-background)] text-[var(--vscode-button-foreground)] hover:bg-[var(--vscode-button-hoverBackground)] disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Create Branch
               </button>

--- a/webview-ui/src/components/CreateWorktreeDialog.tsx
+++ b/webview-ui/src/components/CreateWorktreeDialog.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import type { WorktreeBranchMode, WorktreeInfo } from '@shared/types';
+import { validateGitBranchName } from '@shared/gitRefValidation';
 import { buildAddWorktreeCommand } from '../utils/gitCommandBuilder';
+import { deriveRefNameField } from '../utils/refNameField';
 import { WORKTREE_FOLDER_MISSING_TOOLTIP } from '../utils/worktreeDisplay';
 import { rpcClient } from '../rpc/rpcClient';
 import { CommandPreview } from './CommandPreview';
+import { FieldError } from './FieldError';
 import { dialogContentClassName, dialogContentStyle } from './dialogStyles';
 
 export type WorktreeSourceKind = 'local-branch' | 'remote-branch' | 'commit' | 'tag';
@@ -116,7 +119,9 @@ export function CreateWorktreeDialog({ open, source, existingWorktree, onClose }
         : ' - (no .env* file found)';
 
   const trimmedName = newBranchName.trim();
-  const nameInvalid = branchMode === 'new' && (trimmedName.length === 0 || trimmedName.startsWith('-'));
+  const branchNameField = deriveRefNameField(newBranchName, validateGitBranchName);
+  const nameError = branchMode === 'new' ? branchNameField.error : undefined;
+  const nameInvalid = branchMode === 'new' && !branchNameField.valid;
   const canConfirm = path.trim().length > 0 && !nameInvalid && !busy;
 
   const commandPreview = useMemo(
@@ -227,9 +232,12 @@ export function CreateWorktreeDialog({ open, source, existingWorktree, onClose }
                 type="text"
                 value={newBranchName}
                 onChange={(e) => setNewBranchName(e.target.value)}
+                aria-invalid={!!nameError}
+                aria-describedby={nameError ? 'worktree-branch-name-error' : undefined}
                 className="mt-1 w-full px-2 py-1 text-sm rounded border border-[var(--vscode-input-border)] bg-[var(--vscode-input-background)] text-[var(--vscode-input-foreground)]"
                 placeholder="my-feature"
               />
+              <FieldError id="worktree-branch-name-error" message={nameError} />
             </div>
           )}
 

--- a/webview-ui/src/components/FieldError.tsx
+++ b/webview-ui/src/components/FieldError.tsx
@@ -1,0 +1,15 @@
+interface FieldErrorProps {
+  /** Element id referenced by the input's `aria-describedby`. */
+  id: string;
+  message: string | undefined;
+}
+
+/** Validation message shown under a form input, paired with `aria-invalid`/`aria-describedby` on the input itself. */
+export function FieldError({ id, message }: FieldErrorProps) {
+  if (!message) return null;
+  return (
+    <p id={id} className="mt-1 text-xs text-[var(--vscode-errorForeground)]">
+      {message}
+    </p>
+  );
+}

--- a/webview-ui/src/components/InputDialog.tsx
+++ b/webview-ui/src/components/InputDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { CommandPreview } from './CommandPreview';
+import { FieldError } from './FieldError';
 import { dialogContentClassName, dialogContentStyle } from './dialogStyles';
 
 interface InputDialogProps {
@@ -27,19 +28,14 @@ export function InputDialog({
   buildCommandPreview,
 }: InputDialogProps) {
   const [value, setValue] = useState(defaultValue);
-  const [error, setError] = useState<string>();
+
+  const trimmed = value.trim();
+  const error = trimmed && validate ? validate(trimmed) : undefined;
+  const canSubmit = trimmed.length > 0 && !error;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const trimmed = value.trim();
-    if (!trimmed) return;
-    if (validate) {
-      const err = validate(trimmed);
-      if (err) {
-        setError(err);
-        return;
-      }
-    }
+    if (!canSubmit) return;
     onSubmit(trimmed);
   };
 
@@ -47,7 +43,6 @@ export function InputDialog({
     if (!isOpen) {
       onCancel();
       setValue(defaultValue);
-      setError(undefined);
     }
   };
 
@@ -69,20 +64,17 @@ export function InputDialog({
             <input
               type="text"
               value={value}
-              onChange={(e) => {
-                setValue(e.target.value);
-                setError(undefined);
-              }}
+              onChange={(e) => setValue(e.target.value)}
               placeholder={placeholder}
               autoFocus
+              aria-invalid={!!error}
+              aria-describedby={error ? 'input-dialog-error' : undefined}
               className="w-full px-2 py-1.5 text-sm rounded bg-[var(--vscode-input-background)] text-[var(--vscode-input-foreground)] border border-[var(--vscode-input-border)] focus:outline-none focus:border-[var(--vscode-focusBorder)]"
             />
-            {error && (
-              <p className="mt-1 text-xs text-[var(--vscode-errorForeground)]">{error}</p>
-            )}
+            <FieldError id="input-dialog-error" message={error} />
             {buildCommandPreview && (
               <div className="mt-3">
-                <CommandPreview command={buildCommandPreview(value.trim())} />
+                <CommandPreview command={buildCommandPreview(trimmed)} />
               </div>
             )}
             <div className="flex justify-end gap-2 mt-4">
@@ -94,7 +86,8 @@ export function InputDialog({
               </Dialog.Close>
               <button
                 type="submit"
-                className="px-3 py-1.5 text-sm rounded bg-[var(--vscode-button-background)] text-[var(--vscode-button-foreground)] hover:bg-[var(--vscode-button-hoverBackground)]"
+                disabled={!canSubmit}
+                className="px-3 py-1.5 text-sm rounded bg-[var(--vscode-button-background)] text-[var(--vscode-button-foreground)] hover:bg-[var(--vscode-button-hoverBackground)] disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 OK
               </button>

--- a/webview-ui/src/components/RemoteManagementDialog.tsx
+++ b/webview-ui/src/components/RemoteManagementDialog.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
+import { validateGitRemoteName } from '@shared/gitRefValidation';
 import { useGraphStore } from '../stores/graphStore';
 import { rpcClient } from '../rpc/rpcClient';
 import { ConfirmDialog } from './ConfirmDialog';
+import { FieldError } from './FieldError';
 import { dialogContentClassName, dialogContentStyle } from './dialogStyles';
+import { deriveRefNameField } from '../utils/refNameField';
 
 interface RemoteManagementDialogProps {
   open: boolean;
@@ -31,14 +34,19 @@ export function RemoteManagementDialog({ open, onClose }: RemoteManagementDialog
 
   const [inputName, setInputName] = useState('');
   const [inputUrl, setInputUrl] = useState('');
-  const [nameError, setNameError] = useState<string | undefined>(undefined);
-  const [urlError, setUrlError] = useState<string | undefined>(undefined);
+
+  const trimmedName = inputName.trim();
+  const trimmedUrl = inputUrl.trim();
+  const nameField = deriveRefNameField(inputName, validateGitRemoteName);
+  const duplicateName = remotes.some((r) => r.name === trimmedName);
+  const nameError = nameField.error ?? (duplicateName ? 'A remote with this name already exists' : undefined);
+  const hasUrl = trimmedUrl.length > 0;
+  const canAdd = nameField.valid && !duplicateName && hasUrl;
+  const canSaveEdit = hasUrl;
 
   const resetForm = () => {
     setInputName('');
     setInputUrl('');
-    setNameError(undefined);
-    setUrlError(undefined);
   };
 
   const handleOpenChange = (isOpen: boolean) => {
@@ -73,59 +81,18 @@ export function RemoteManagementDialog({ open, onClose }: RemoteManagementDialog
     setEditingRemoteName(undefined);
   };
 
-  const validateAdd = (): boolean => {
-    let valid = true;
-    const trimmedName = inputName.trim();
-    const trimmedUrl = inputUrl.trim();
-
-    if (!trimmedName) {
-      setNameError('Name is required');
-      valid = false;
-    } else if (trimmedName.includes(' ')) {
-      setNameError('Name cannot contain spaces');
-      valid = false;
-    } else if (trimmedName.startsWith('-')) {
-      setNameError('Name cannot start with -');
-      valid = false;
-    } else if (remotes.some((r) => r.name === trimmedName)) {
-      setNameError('A remote with this name already exists');
-      valid = false;
-    } else {
-      setNameError(undefined);
-    }
-
-    if (!trimmedUrl) {
-      setUrlError('URL is required');
-      valid = false;
-    } else {
-      setUrlError(undefined);
-    }
-
-    return valid;
-  };
-
-  const validateEdit = (): boolean => {
-    const trimmedUrl = inputUrl.trim();
-    if (!trimmedUrl) {
-      setUrlError('URL is required');
-      return false;
-    }
-    setUrlError(undefined);
-    return true;
-  };
-
   const handleAddSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateAdd()) return;
-    rpcClient.addRemote(inputName.trim(), inputUrl.trim());
+    if (!canAdd) return;
+    rpcClient.addRemote(trimmedName, trimmedUrl);
     setMode('view');
     resetForm();
   };
 
   const handleEditSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!validateEdit() || !editingRemoteName) return;
-    rpcClient.editRemote(editingRemoteName, inputUrl.trim());
+    if (!canSaveEdit || !editingRemoteName) return;
+    rpcClient.editRemote(editingRemoteName, trimmedUrl);
     setMode('view');
     resetForm();
     setEditingRemoteName(undefined);
@@ -212,22 +179,20 @@ export function RemoteManagementDialog({ open, onClose }: RemoteManagementDialog
                             <input
                               type="text"
                               value={inputUrl}
-                              onChange={(e) => {
-                                setInputUrl(e.target.value);
-                                setUrlError(undefined);
-                              }}
+                              onChange={(e) => setInputUrl(e.target.value)}
                               autoFocus
                               className={inputClass}
                             />
-                            {urlError && (
-                              <p className="mt-1 text-xs text-[var(--vscode-errorForeground)]">{urlError}</p>
-                            )}
                           </div>
                           <div className="flex justify-end gap-2">
                             <button type="button" className={buttonSecondaryClass} onClick={handleCancelForm}>
                               Cancel
                             </button>
-                            <button type="submit" className={buttonPrimaryClass}>
+                            <button
+                              type="submit"
+                              disabled={!canSaveEdit}
+                              className={`${buttonPrimaryClass} disabled:opacity-50 disabled:cursor-not-allowed`}
+                            >
                               Save
                             </button>
                           </div>
@@ -250,17 +215,14 @@ export function RemoteManagementDialog({ open, onClose }: RemoteManagementDialog
                   <input
                     type="text"
                     value={inputName}
-                    onChange={(e) => {
-                      setInputName(e.target.value);
-                      setNameError(undefined);
-                    }}
+                    onChange={(e) => setInputName(e.target.value)}
                     placeholder="origin"
                     autoFocus
+                    aria-invalid={!!nameError}
+                    aria-describedby={nameError ? 'remote-name-error' : undefined}
                     className={inputClass}
                   />
-                  {nameError && (
-                    <p className="mt-1 text-xs text-[var(--vscode-errorForeground)]">{nameError}</p>
-                  )}
+                  <FieldError id="remote-name-error" message={nameError} />
                 </div>
                 <div>
                   <label className="block text-xs text-[var(--vscode-descriptionForeground)] mb-1">
@@ -269,22 +231,20 @@ export function RemoteManagementDialog({ open, onClose }: RemoteManagementDialog
                   <input
                     type="text"
                     value={inputUrl}
-                    onChange={(e) => {
-                      setInputUrl(e.target.value);
-                      setUrlError(undefined);
-                    }}
+                    onChange={(e) => setInputUrl(e.target.value)}
                     placeholder="https://github.com/user/repo.git"
                     className={inputClass}
                   />
-                  {urlError && (
-                    <p className="mt-1 text-xs text-[var(--vscode-errorForeground)]">{urlError}</p>
-                  )}
                 </div>
                 <div className="flex justify-end gap-2">
                   <button type="button" className={buttonSecondaryClass} onClick={handleCancelForm}>
                     Cancel
                   </button>
-                  <button type="submit" className={buttonPrimaryClass}>
+                  <button
+                    type="submit"
+                    disabled={!canAdd}
+                    className={`${buttonPrimaryClass} disabled:opacity-50 disabled:cursor-not-allowed`}
+                  >
                     Add
                   </button>
                 </div>

--- a/webview-ui/src/components/TagCreationDialog.tsx
+++ b/webview-ui/src/components/TagCreationDialog.tsx
@@ -6,7 +6,9 @@ import { rpcClient } from '../rpc/rpcClient';
 import { useGraphStore } from '../stores/graphStore';
 import { buildTagCommand } from '../utils/gitCommandBuilder';
 import { resolveDefaultRemoteName } from '../utils/resolveDefaultRemote';
+import { deriveRefNameField } from '../utils/refNameField';
 import { CommandPreview } from './CommandPreview';
+import { FieldError } from './FieldError';
 import { dialogContentClassName, dialogContentStyle } from './dialogStyles';
 
 interface TagCreationDialogProps {
@@ -25,9 +27,7 @@ export function TagCreationDialog({ open, commit, onClose }: TagCreationDialogPr
   const hasRemote = remotes.length > 0;
   const remote = resolveDefaultRemoteName(remotes);
   const trimmedName = name.trim();
-  const nameValidation = validateGitTagName(name);
-  const nameError = name ? nameValidation.message : undefined;
-  const canCreate = nameValidation.valid;
+  const { error: nameError, valid: canCreate } = deriveRefNameField(name, validateGitTagName);
 
   const resetState = () => {
     setName('');
@@ -80,9 +80,7 @@ export function TagCreationDialog({ open, commit, onClose }: TagCreationDialogPr
                 aria-describedby={nameError ? 'tag-name-error' : undefined}
                 className="w-full px-2 py-1.5 text-sm rounded bg-[var(--vscode-input-background)] text-[var(--vscode-input-foreground)] border border-[var(--vscode-input-border)] focus:outline-none focus:border-[var(--vscode-focusBorder)]"
               />
-              {nameError && (
-                <p id="tag-name-error" className="mt-1 text-xs text-[var(--vscode-errorForeground)]">{nameError}</p>
-              )}
+              <FieldError id="tag-name-error" message={nameError} />
             </div>
             <div>
               <label className="block text-sm text-[var(--vscode-foreground)] mb-1">

--- a/webview-ui/src/utils/refNameField.ts
+++ b/webview-ui/src/utils/refNameField.ts
@@ -1,0 +1,25 @@
+import type { GitRefNameValidation } from '@shared/gitRefValidation';
+
+export interface RefNameFieldState {
+  /** Error to show under the input; suppressed while the field is still empty. */
+  error: string | undefined;
+  /** True when the current value passes validation (an empty value is not valid). */
+  valid: boolean;
+}
+
+/**
+ * Derives the live-validation state shared by every ref-name input: run the
+ * validator on each keystroke, but only surface its message once the user has
+ * typed something, so a pristine field shows a disabled submit button without
+ * an error.
+ */
+export function deriveRefNameField(
+  value: string,
+  validate: (rawName: string) => GitRefNameValidation
+): RefNameFieldState {
+  const validation = validate(value);
+  return {
+    error: value ? validation.message : undefined,
+    valid: validation.valid,
+  };
+}


### PR DESCRIPTION
- Added live validation for branch and remote names in dialogs, ensuring invalid names are caught early.
- Generalized the tag-name validator to a ref-name validator, applying consistent rules across branches, remotes, and tags.
- Updated relevant services and UI components to utilize the new validation logic, improving user experience and error handling.
- Introduced new validation tests for branch and remote names to ensure compliance with Git naming conventions.