### PR TITLE
Update to version 5.6.1 and improve commit details panel behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "speedy-git-ext" extension will be documented in this
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [5.6.1] - 2026-07-20
+
+### Fixed
+- **Clicking a commit no longer leaves the row hidden behind the bottom details panel.** When the commit details panel is positioned at the bottom, opening it by clicking a commit near the bottom of the graph could cover the very row that was clicked, since the panel only appears once the commit's details have loaded. The graph now scrolls just enough to keep the clicked row visible directly above the panel — including when moving the panel from the right to the bottom while a low row is selected. Rows that are already fully visible are left alone, so there's no unnecessary scrolling.
+
 ## [5.6.0] - 2026-07-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speedy-git-ext",
   "displayName": "Speedy Git",
   "description": "A performance-first, lightweight Git graph visualization extension for VS Code",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "publisher": "onlineeric",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1093,8 +1093,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001805:
-    resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -3433,7 +3433,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.43
-      caniuse-lite: 1.0.30001805
+      caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -3464,7 +3464,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001805: {}
+  caniuse-lite@1.0.30001806: {}
 
   chai@6.2.2: {}
 

--- a/webview-ui/src/components/GraphContainer.tsx
+++ b/webview-ui/src/components/GraphContainer.tsx
@@ -15,6 +15,7 @@ import {
   resolveCommitTableLayout,
   setCommitTableColumnPreferredWidth,
 } from '../utils/commitTableLayout';
+import { computeScrollTopForRow } from '../utils/rowVisibility';
 
 const ROW_HEIGHT = 28;
 
@@ -180,6 +181,29 @@ export function GraphContainer({ selectedCommit, onSelectCommit }: GraphContaine
       virtualizer.scrollToIndex(selectedCommitIndex, { align: 'auto' });
     }
   }, [selectedCommitIndex, virtualizer]);
+
+  // The details panel opens only when commit details arrive (after the click),
+  // so the bottom panel can shrink the viewport and hide the row the user just
+  // clicked. Once the panel is open at the bottom, re-scroll the selected row
+  // into the reduced viewport. Reading clientHeight here sees the post-panel
+  // layout because the panel mounts in the same React commit.
+  const detailsPanelOpen = useGraphStore((state) => state.detailsPanelOpen);
+  const detailsPanelPosition = useGraphStore((state) => state.detailsPanelPosition);
+  useEffect(() => {
+    if (!detailsPanelOpen || detailsPanelPosition !== 'bottom') return;
+    const element = containerRef.current;
+    if (!element) return;
+    const rowIndex = useGraphStore.getState().selectedCommitIndex;
+    const newScrollTop = computeScrollTopForRow({
+      rowIndex,
+      rowHeight: ROW_HEIGHT,
+      scrollTop: element.scrollTop,
+      viewportHeight: element.clientHeight,
+    });
+    if (newScrollTop !== null) {
+      element.scrollTo({ top: newScrollTop });
+    }
+  }, [detailsPanelOpen, detailsPanelPosition]);
 
   // Go to HEAD: center the flashed row (overriding the minimal 'auto' scroll
   // above — this effect runs after it) and clear the flash once it has played.

--- a/webview-ui/src/utils/__tests__/rowVisibility.test.ts
+++ b/webview-ui/src/utils/__tests__/rowVisibility.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { computeScrollTopForRow } from '../rowVisibility';
+
+const ROW_HEIGHT = 28;
+
+describe('computeScrollTopForRow', () => {
+  it('returns null when the row is fully visible', () => {
+    // Row 10 spans 280–308; viewport shows 200–500
+    expect(
+      computeScrollTopForRow({ rowIndex: 10, rowHeight: ROW_HEIGHT, scrollTop: 200, viewportHeight: 300 })
+    ).toBeNull();
+  });
+
+  it('scrolls down just enough when the row is hidden below the viewport', () => {
+    // Row 20 spans 560–588; viewport shows 0–400 → align row bottom to viewport bottom
+    expect(
+      computeScrollTopForRow({ rowIndex: 20, rowHeight: ROW_HEIGHT, scrollTop: 0, viewportHeight: 400 })
+    ).toBe(588 - 400);
+  });
+
+  it('scrolls down when the row is only partially covered at the bottom', () => {
+    // Row 14 spans 392–420; viewport shows 0–400 → bottom 20px are covered
+    expect(
+      computeScrollTopForRow({ rowIndex: 14, rowHeight: ROW_HEIGHT, scrollTop: 0, viewportHeight: 400 })
+    ).toBe(420 - 400);
+  });
+
+  it('scrolls up just enough when the row is hidden above the viewport', () => {
+    // Row 2 spans 56–84; viewport shows 300–600 → align row top to viewport top
+    expect(
+      computeScrollTopForRow({ rowIndex: 2, rowHeight: ROW_HEIGHT, scrollTop: 300, viewportHeight: 300 })
+    ).toBe(56);
+  });
+
+  it('returns null when the row touches the viewport bottom edge exactly', () => {
+    // Row 14 spans 392–420; viewport shows 20–420
+    expect(
+      computeScrollTopForRow({ rowIndex: 14, rowHeight: ROW_HEIGHT, scrollTop: 20, viewportHeight: 400 })
+    ).toBeNull();
+  });
+
+  it('returns null for invalid inputs', () => {
+    expect(
+      computeScrollTopForRow({ rowIndex: -1, rowHeight: ROW_HEIGHT, scrollTop: 0, viewportHeight: 400 })
+    ).toBeNull();
+    expect(
+      computeScrollTopForRow({ rowIndex: 5, rowHeight: 0, scrollTop: 0, viewportHeight: 400 })
+    ).toBeNull();
+    expect(
+      computeScrollTopForRow({ rowIndex: 5, rowHeight: ROW_HEIGHT, scrollTop: 0, viewportHeight: 0 })
+    ).toBeNull();
+  });
+});

--- a/webview-ui/src/utils/rowVisibility.ts
+++ b/webview-ui/src/utils/rowVisibility.ts
@@ -1,0 +1,42 @@
+/**
+ * Computes the minimal scrollTop needed to bring a virtualized row fully into
+ * the scroll container's viewport. Used when the bottom commit-details panel
+ * opens and shrinks the graph viewport, potentially hiding the row the user
+ * just clicked beneath the panel.
+ */
+export interface RowScrollArgs {
+  /** Zero-based index of the row in the virtualized list */
+  rowIndex: number;
+  /** Fixed height of each row in pixels */
+  rowHeight: number;
+  /** Current scrollTop of the scroll container */
+  scrollTop: number;
+  /** Current visible height (clientHeight) of the scroll container */
+  viewportHeight: number;
+}
+
+/**
+ * Returns the new scrollTop that makes the row fully visible, or null when the
+ * row is already fully visible (no scroll needed). Scrolls the minimal amount:
+ * rows hidden below the viewport are aligned to its bottom edge, rows hidden
+ * above are aligned to its top edge.
+ */
+export function computeScrollTopForRow({
+  rowIndex,
+  rowHeight,
+  scrollTop,
+  viewportHeight,
+}: RowScrollArgs): number | null {
+  if (rowIndex < 0 || rowHeight <= 0 || viewportHeight <= 0) return null;
+
+  const rowTop = rowIndex * rowHeight;
+  const rowBottom = rowTop + rowHeight;
+
+  if (rowBottom > scrollTop + viewportHeight) {
+    return rowBottom - viewportHeight;
+  }
+  if (rowTop < scrollTop) {
+    return rowTop;
+  }
+  return null;
+}


### PR DESCRIPTION
- Incremented version number to 5.6.1 in package.json.
- Added a fix to ensure that clicking a commit keeps the selected row visible when the details panel is opened at the bottom, enhancing user experience.
- Introduced a new utility function to compute the necessary scroll position for the selected row when the details panel is displayed.
- Added tests for the new row visibility utility to ensure correct scrolling behavior.